### PR TITLE
fix: rename plugin id to football-notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Contributor tooling in this repository currently requires Node.js 20.17 or newer
 The canonical local setup is to clone this repository directly into the plugin folder inside the test vault:
 
 ```text
-<Vault>/.obsidian/plugins/obsidian-football-notes
+<Vault>/.obsidian/plugins/football-notes
 ```
 
 That keeps the generated `main.js`, `manifest.json`, and `styles.css` at the plugin root where Obsidian expects them.
@@ -20,7 +20,7 @@ That keeps the generated `main.js`, `manifest.json`, and `styles.css` at the plu
 2. Clone this repository into:
 
     ```text
-    <Vault>/.obsidian/plugins/obsidian-football-notes
+    <Vault>/.obsidian/plugins/football-notes
     ```
 
 3. Install dependencies:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Use a dedicated Obsidian test vault for development.
 Install the plugin into:
 
 ```text
-<Vault>/.obsidian/plugins/obsidian-football-notes/
+<Vault>/.obsidian/plugins/football-notes/
 ```
 
 and place `main.js`, `manifest.json`, and `styles.css` there.

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-	"id": "obsidian-football-notes",
+	"id": "football-notes",
 	"name": "Football Notes",
 	"version": "0.1.0",
 	"minAppVersion": "0.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "obsidian-football-notes",
+	"name": "football-notes",
 	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "obsidian-football-notes",
+			"name": "football-notes",
 			"version": "0.1.0",
 			"license": "0-BSD",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "obsidian-football-notes",
+	"name": "football-notes",
 	"version": "0.1.0",
 	"description": "Create structured football notes in Obsidian.",
 	"main": "main.js",


### PR DESCRIPTION
This pull request updates the plugin's name from "obsidian-football-notes" to "football-notes" across the codebase and documentation to ensure consistency in naming and installation paths.

**Plugin renaming and path updates:**

* Changed the plugin ID in `manifest.json` from `obsidian-football-notes` to `football-notes`.
* Updated the package name in `package.json` from `obsidian-football-notes` to `football-notes`.

**Documentation updates:**

* Updated installation and setup instructions in `README.md` to use the new plugin folder name `football-notes` instead of `obsidian-football-notes`.
* Revised plugin folder references in `CONTRIBUTING.md` to reflect the new name and path. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L12-R12) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L23-R23)

**Related issues:**

* Resolve #11 