### PR TITLE
feat: add match note schema and file creation services

### DIFF
--- a/docs/match-note-schema.md
+++ b/docs/match-note-schema.md
@@ -1,0 +1,59 @@
+# Match note schema
+
+This document defines the canonical MVP schema for generated football match notes.
+
+The goal is to keep match notes predictable, Dataview-friendly, and safe to extend in later issues without rewriting the basic note shape.
+
+## Frontmatter
+
+### Required fields
+
+```yaml
+type: match-note
+sport: football
+source_url: 'https://example.com/match/123'
+```
+
+### Reserved fields for later issues
+
+These fields are part of the planned schema, but they are not required or emitted by the current MVP template yet:
+
+- `source_host`
+- `competition`
+- `match_date`
+- `home_team`
+- `away_team`
+- `tags`
+
+## Body structure
+
+Generated match notes should use this exact section order:
+
+```markdown
+# Match
+
+## Snapshot
+
+## Lineups
+
+## Match stats
+
+## Timeline
+
+## My observations
+
+## Tactical notes
+```
+
+The current MVP template should create section headings only. It should not add starter prose or machine-generated filler text inside the sections.
+
+## Ownership
+
+- The plugin owns the initial skeleton it generates.
+- User-authored content begins after note creation.
+- Later refresh or update logic must preserve user-written content in these sections.
+
+## Naming
+
+- Placeholder note title for the current MVP template: `New match note`
+- File naming rules are intentionally deferred to the later file-creation issue.

--- a/docs/match-note-schema.md
+++ b/docs/match-note-schema.md
@@ -56,4 +56,4 @@ The current MVP template should create section headings only. It should not add 
 ## Naming
 
 - Placeholder note title for the current MVP template: `New match note`
-- File naming rules are intentionally deferred to the later file-creation issue.
+- File naming is handled by the note-creation service and is not part of the schema contract.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { Plugin } from 'obsidian';
 import { DEFAULT_SETTINGS, FootballNotesSettings, FootballNotesSettingTab } from './settings';
+import { normalizeMatchNotesFolder } from './types';
 
 export default class FootballNotesPlugin extends Plugin {
 	settings: FootballNotesSettings;
@@ -10,14 +11,24 @@ export default class FootballNotesPlugin extends Plugin {
 	}
 
 	async loadSettings() {
-		this.settings = Object.assign(
-			{},
-			DEFAULT_SETTINGS,
-			(await this.loadData()) as Partial<FootballNotesSettings>,
+		const loadedSettings = (await this.loadData()) as Partial<FootballNotesSettings>;
+		const notesFolder = normalizeMatchNotesFolder(
+			loadedSettings?.notesFolder ?? DEFAULT_SETTINGS.notesFolder,
 		);
+		const shouldPersistNormalizedFolder =
+			loadedSettings?.notesFolder !== undefined && loadedSettings.notesFolder !== notesFolder;
+
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, loadedSettings, {
+			notesFolder,
+		});
+
+		if (shouldPersistNormalizedFolder) {
+			await this.saveSettings();
+		}
 	}
 
 	async saveSettings() {
+		this.settings.notesFolder = normalizeMatchNotesFolder(this.settings.notesFolder);
 		await this.saveData(this.settings);
 	}
 }

--- a/src/services/match-note-files.ts
+++ b/src/services/match-note-files.ts
@@ -1,0 +1,52 @@
+import { TFile, TFolder, Vault } from 'obsidian';
+
+import type { MatchNoteInput } from '../types';
+import { createMatchNotePath, getFolderCreationChain } from './match-note-paths';
+import { createMatchNoteDraft } from './match-note-template';
+
+export async function createMatchNoteFile(vault: Vault, input: MatchNoteInput): Promise<TFile> {
+	const draft = createMatchNoteDraft(input);
+	const now = new Date();
+
+	await ensureFolderExists(vault, draft.folder);
+
+	const filePath = findAvailableMatchNotePath(vault, draft.folder, draft.title, now);
+
+	return await vault.create(filePath, draft.content);
+}
+
+function findAvailableMatchNotePath(
+	vault: Vault,
+	folder: string,
+	title: string,
+	now: Date,
+): string {
+	let attempt = 1;
+
+	for (;;) {
+		const candidatePath = createMatchNotePath(folder, title, now, attempt);
+
+		if (vault.getAbstractFileByPath(candidatePath) === null) {
+			return candidatePath;
+		}
+
+		attempt += 1;
+	}
+}
+
+async function ensureFolderExists(vault: Vault, folder: string): Promise<void> {
+	for (const folderPath of getFolderCreationChain(folder)) {
+		const existingFile = vault.getAbstractFileByPath(folderPath);
+
+		if (existingFile === null) {
+			await vault.createFolder(folderPath);
+			continue;
+		}
+
+		if (!(existingFile instanceof TFolder)) {
+			throw new Error(
+				`Cannot create match note folder because "${folderPath}" already exists as a file.`,
+			);
+		}
+	}
+}

--- a/src/services/match-note-files.ts
+++ b/src/services/match-note-files.ts
@@ -10,27 +10,39 @@ export async function createMatchNoteFile(vault: Vault, input: MatchNoteInput): 
 
 	await ensureFolderExists(vault, draft.folder);
 
-	const filePath = findAvailableMatchNotePath(vault, draft.folder, draft.title, now);
-
-	return await vault.create(filePath, draft.content);
+	return await createMatchNoteFileWithRetry(vault, draft.folder, draft.title, now, draft.content);
 }
 
-function findAvailableMatchNotePath(
+async function createMatchNoteFileWithRetry(
 	vault: Vault,
 	folder: string,
 	title: string,
 	now: Date,
-): string {
+	content: string,
+): Promise<TFile> {
 	let attempt = 1;
 
 	for (;;) {
 		const candidatePath = createMatchNotePath(folder, title, now, attempt);
 
-		if (vault.getAbstractFileByPath(candidatePath) === null) {
-			return candidatePath;
+		if (vault.getAbstractFileByPath(candidatePath) !== null) {
+			attempt += 1;
+			continue;
 		}
 
-		attempt += 1;
+		try {
+			return await vault.create(candidatePath, content);
+		} catch (error) {
+			if (
+				vault.getAbstractFileByPath(candidatePath) !== null ||
+				isAlreadyExistsError(error)
+			) {
+				attempt += 1;
+				continue;
+			}
+
+			throw error;
+		}
 	}
 }
 
@@ -39,7 +51,27 @@ async function ensureFolderExists(vault: Vault, folder: string): Promise<void> {
 		const existingFile = vault.getAbstractFileByPath(folderPath);
 
 		if (existingFile === null) {
-			await vault.createFolder(folderPath);
+			try {
+				await vault.createFolder(folderPath);
+			} catch (error) {
+				const createdFolder = vault.getAbstractFileByPath(folderPath);
+
+				if (createdFolder instanceof TFolder) {
+					continue;
+				}
+
+				if (createdFolder !== null) {
+					throw new Error(
+						`Cannot create match note folder because "${folderPath}" already exists as a file.`,
+					);
+				}
+
+				if (isAlreadyExistsError(error)) {
+					continue;
+				}
+
+				throw error;
+			}
 			continue;
 		}
 
@@ -49,4 +81,8 @@ async function ensureFolderExists(vault: Vault, folder: string): Promise<void> {
 			);
 		}
 	}
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+	return error instanceof Error && error.message.toLowerCase().includes('already exists');
 }

--- a/src/services/match-note-paths.ts
+++ b/src/services/match-note-paths.ts
@@ -1,0 +1,55 @@
+import { normalizePath } from 'obsidian';
+
+const MATCH_NOTE_FILE_EXTENSION = '.md';
+
+export function createMatchNoteTimestamp(now: Date): string {
+	return [
+		now.getFullYear().toString().padStart(4, '0'),
+		'-',
+		(now.getMonth() + 1).toString().padStart(2, '0'),
+		'-',
+		now.getDate().toString().padStart(2, '0'),
+		' ',
+		now.getHours().toString().padStart(2, '0'),
+		'-',
+		now.getMinutes().toString().padStart(2, '0'),
+		'-',
+		now.getSeconds().toString().padStart(2, '0'),
+	].join('');
+}
+
+export function createMatchNoteFilename(title: string, now: Date): string {
+	return `${title} ${createMatchNoteTimestamp(now)}${MATCH_NOTE_FILE_EXTENSION}`;
+}
+
+export function createMatchNoteCandidateFilename(
+	title: string,
+	now: Date,
+	attempt: number,
+): string {
+	const baseFilename = createMatchNoteFilename(title, now);
+
+	if (attempt <= 1) {
+		return baseFilename;
+	}
+
+	const suffix = ` ${attempt}`;
+
+	return baseFilename.replace(MATCH_NOTE_FILE_EXTENSION, `${suffix}${MATCH_NOTE_FILE_EXTENSION}`);
+}
+
+export function createMatchNotePath(folder: string, title: string, now: Date, attempt = 1): string {
+	return normalizePath(`${folder}/${createMatchNoteCandidateFilename(title, now, attempt)}`);
+}
+
+export function getFolderCreationChain(folder: string): string[] {
+	const normalizedFolder = normalizePath(folder);
+
+	if (normalizedFolder === '.' || normalizedFolder === '/') {
+		return [];
+	}
+
+	return normalizedFolder
+		.split('/')
+		.map((_, index, segments) => segments.slice(0, index + 1).join('/'));
+}

--- a/src/services/match-note-paths.ts
+++ b/src/services/match-note-paths.ts
@@ -1,5 +1,7 @@
 import { normalizePath } from 'obsidian';
 
+import { normalizeMatchNotesFolder } from '../types';
+
 const MATCH_NOTE_FILE_EXTENSION = '.md';
 
 export function createMatchNoteTimestamp(now: Date): string {
@@ -40,11 +42,15 @@ export function createMatchNoteCandidateFilename(
 }
 
 export function createMatchNotePath(folder: string, title: string, now: Date, attempt = 1): string {
-	return normalizePath(`${folder}/${createMatchNoteCandidateFilename(title, now, attempt)}`);
+	const normalizedFolder = normalizeMatchNotesFolder(folder);
+
+	return normalizePath(
+		`${normalizedFolder}/${createMatchNoteCandidateFilename(title, now, attempt)}`,
+	);
 }
 
 export function getFolderCreationChain(folder: string): string[] {
-	const normalizedFolder = normalizePath(folder);
+	const normalizedFolder = normalizeMatchNotesFolder(folder);
 
 	if (normalizedFolder === '.' || normalizedFolder === '/') {
 		return [];

--- a/src/services/match-note-paths.ts
+++ b/src/services/match-note-paths.ts
@@ -4,17 +4,17 @@ const MATCH_NOTE_FILE_EXTENSION = '.md';
 
 export function createMatchNoteTimestamp(now: Date): string {
 	return [
-		now.getFullYear().toString().padStart(4, '0'),
+		padNumber(now.getFullYear(), 4),
 		'-',
-		(now.getMonth() + 1).toString().padStart(2, '0'),
+		padNumber(now.getMonth() + 1, 2),
 		'-',
-		now.getDate().toString().padStart(2, '0'),
+		padNumber(now.getDate(), 2),
 		' ',
-		now.getHours().toString().padStart(2, '0'),
+		padNumber(now.getHours(), 2),
 		'-',
-		now.getMinutes().toString().padStart(2, '0'),
+		padNumber(now.getMinutes(), 2),
 		'-',
-		now.getSeconds().toString().padStart(2, '0'),
+		padNumber(now.getSeconds(), 2),
 	].join('');
 }
 
@@ -34,8 +34,9 @@ export function createMatchNoteCandidateFilename(
 	}
 
 	const suffix = ` ${attempt}`;
+	const baseName = baseFilename.slice(0, -MATCH_NOTE_FILE_EXTENSION.length);
 
-	return baseFilename.replace(MATCH_NOTE_FILE_EXTENSION, `${suffix}${MATCH_NOTE_FILE_EXTENSION}`);
+	return `${baseName}${suffix}${MATCH_NOTE_FILE_EXTENSION}`;
 }
 
 export function createMatchNotePath(folder: string, title: string, now: Date, attempt = 1): string {
@@ -52,4 +53,14 @@ export function getFolderCreationChain(folder: string): string[] {
 	return normalizedFolder
 		.split('/')
 		.map((_, index, segments) => segments.slice(0, index + 1).join('/'));
+}
+
+function padNumber(value: number, width: number): string {
+	const valueString = value.toString();
+
+	if (valueString.length >= width) {
+		return valueString;
+	}
+
+	return `${'0000'.slice(0, width - valueString.length)}${valueString}`;
 }

--- a/src/services/match-note-template.ts
+++ b/src/services/match-note-template.ts
@@ -20,6 +20,10 @@ export function createMatchNoteDraft(input: MatchNoteInput): MatchNoteDraft {
 	const destinationFolder = normalizeMatchNotesFolder(input.destinationFolder);
 	const sourceUrl = input.sourceUrl.trim();
 
+	if (sourceUrl.length === 0) {
+		throw new Error('Match note source URL cannot be empty.');
+	}
+
 	return {
 		title: 'New match note',
 		folder: destinationFolder,

--- a/src/services/match-note-template.ts
+++ b/src/services/match-note-template.ts
@@ -28,7 +28,11 @@ export function createMatchNoteDraft(input: MatchNoteInput): MatchNoteDraft {
 }
 
 function buildMatchNoteMarkdown(sourceUrl: string): string {
-	const sectionHeadings = MATCH_NOTE_SECTIONS.flatMap((section) => [`## ${section}`, '']);
+	const sectionHeadings: string[] = [];
+
+	for (const section of MATCH_NOTE_SECTIONS) {
+		sectionHeadings.push(`## ${section}`, '');
+	}
 
 	return [
 		'---',

--- a/src/services/match-note-template.ts
+++ b/src/services/match-note-template.ts
@@ -1,6 +1,21 @@
 import { normalizeMatchNotesFolder } from '../types';
 import type { MatchNoteDraft, MatchNoteInput } from '../types';
 
+const MATCH_NOTE_FRONTMATTER = {
+	type: 'match-note',
+	sport: 'football',
+	sourceUrlKey: 'source_url',
+} as const;
+
+const MATCH_NOTE_SECTIONS = [
+	'Snapshot',
+	'Lineups',
+	'Match stats',
+	'Timeline',
+	'My observations',
+	'Tactical notes',
+] as const;
+
 export function createMatchNoteDraft(input: MatchNoteInput): MatchNoteDraft {
 	const destinationFolder = normalizeMatchNotesFolder(input.destinationFolder);
 	const sourceUrl = input.sourceUrl.trim();
@@ -13,25 +28,18 @@ export function createMatchNoteDraft(input: MatchNoteInput): MatchNoteDraft {
 }
 
 function buildMatchNoteMarkdown(sourceUrl: string): string {
+	const sectionHeadings = MATCH_NOTE_SECTIONS.flatMap((section) => [`## ${section}`, '']);
+
 	return [
 		'---',
-		'type: match-note',
-		'status: draft',
-		`source: ${formatFrontmatterString(sourceUrl)}`,
+		`type: ${MATCH_NOTE_FRONTMATTER.type}`,
+		`sport: ${MATCH_NOTE_FRONTMATTER.sport}`,
+		`${MATCH_NOTE_FRONTMATTER.sourceUrlKey}: ${formatFrontmatterString(sourceUrl)}`,
 		'---',
 		'',
 		'# Match',
 		'',
-		'## Summary',
-		'',
-		'## Match details',
-		'',
-		'## Lineups',
-		'',
-		'## Timeline',
-		'',
-		'## Notes',
-		'',
+		...sectionHeadings,
 	].join('\n');
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,11 +9,19 @@ export function normalizeMatchNotesFolder(folder: string): string {
 		return DEFAULT_MATCH_NOTES_FOLDER;
 	}
 
+	if (containsParentDirectorySegment(trimmedFolder)) {
+		return DEFAULT_MATCH_NOTES_FOLDER;
+	}
+
 	const normalizedFolder = normalizePath(trimmedFolder).replace(/^\/+/, '');
 
 	return normalizedFolder.length > 0 && normalizedFolder !== '.'
 		? normalizedFolder
 		: DEFAULT_MATCH_NOTES_FOLDER;
+}
+
+function containsParentDirectorySegment(folder: string): boolean {
+	return folder.split(/[\\/]/).some((segment) => segment === '..');
 }
 
 export interface MatchNoteInput {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,19 @@
+import { normalizePath } from 'obsidian';
+
 export const DEFAULT_MATCH_NOTES_FOLDER = 'Football notes/matches';
 
 export function normalizeMatchNotesFolder(folder: string): string {
 	const trimmedFolder = folder.trim();
 
-	return trimmedFolder.length > 0 ? trimmedFolder : DEFAULT_MATCH_NOTES_FOLDER;
+	if (trimmedFolder.length === 0) {
+		return DEFAULT_MATCH_NOTES_FOLDER;
+	}
+
+	const normalizedFolder = normalizePath(trimmedFolder).replace(/^\/+/, '');
+
+	return normalizedFolder.length > 0 && normalizedFolder !== '.'
+		? normalizedFolder
+		: DEFAULT_MATCH_NOTES_FOLDER;
 }
 
 export interface MatchNoteInput {


### PR DESCRIPTION
This pull request introduces the initial implementation for generating football match notes, including a canonical schema, file creation logic, and consistent template structure. The changes establish a predictable and extensible format for match notes and ensure safe file creation within the Obsidian vault.

**Match note schema and template standardization:**

* Added `docs/match-note-schema.md` to define the canonical MVP schema for football match notes, specifying required frontmatter fields, reserved fields for future use, section ordering, and ownership/naming conventions.
* Updated the match note template in `src/services/match-note-template.ts` to use the new schema: required frontmatter fields (`type`, `sport`, `source_url`), and a standardized set of section headings with no starter prose. [[1]](diffhunk://#diff-d4d9b084911ae5ccb42abd4e7adade8cd4d09e5e6c2babd0b991b45cc613c942R4-R18) [[2]](diffhunk://#diff-d4d9b084911ae5ccb42abd4e7adade8cd4d09e5e6c2babd0b991b45cc613c942R31-R42)

**File creation and path management:**

* Added `src/services/match-note-files.ts` to handle creation of match note files in the vault, including logic to ensure folders exist and to avoid filename collisions by incrementing a numeric suffix.
* Added `src/services/match-note-paths.ts` to generate normalized file paths, timestamped filenames, and folder creation chains for match notes.

**Related Issues:**

* Resolve #13 
* Resolve #18 
