### PR TITLE
feat: add match URL parsing and validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,6 @@ jobs:
                   cache: 'npm'
             - run: npm ci
             - run: npm run version:check
+            - run: npm run test
             - run: npm run build
             - run: npm run lint

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,2 @@
+npm run test
 npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ npm run format:check
 This repository installs local Git hooks with Husky:
 
 - `pre-commit`: runs `lint-staged` to format and lint staged files
-- `pre-push`: runs `npm run build`
+- `pre-push`: runs `npm run test` and `npm run build`
 
 If hooks stop working after reinstalling dependencies, run:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ That keeps the generated `main.js`, `manifest.json`, and `styles.css` at the plu
 Run these before pushing significant changes:
 
 ```bash
+npm run test
 npm run build
 npm run lint
 npm run format:check

--- a/docs/match-note-schema.md
+++ b/docs/match-note-schema.md
@@ -14,6 +14,8 @@ sport: football
 source_url: 'https://example.com/match/123'
 ```
 
+`source_url` should be written from the plugin's normalized URL parser output rather than raw user input.
+
 ### Reserved fields for later issues
 
 These fields are part of the planned schema, but they are not required or emitted by the current MVP template yet:

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -31,6 +31,12 @@ export default tseslint.config(
 			],
 		},
 	},
+	{
+		files: ['src/**/*.test.ts'],
+		rules: {
+			'import/no-nodejs-modules': 'off',
+		},
+	},
 	globalIgnores([
 		'node_modules',
 		'dist',

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+		"test": "node --import jiti/register --test src/services/match-url-parser.test.ts",
 		"prepare": "husky",
 		"format": "prettier . --write",
 		"format:check": "prettier . --check",

--- a/src/services/match-note-template.ts
+++ b/src/services/match-note-template.ts
@@ -18,7 +18,7 @@ const MATCH_NOTE_SECTIONS = [
 
 export function createMatchNoteDraft(input: MatchNoteInput): MatchNoteDraft {
 	const destinationFolder = normalizeMatchNotesFolder(input.destinationFolder);
-	const sourceUrl = input.sourceUrl.trim();
+	const sourceUrl = input.source.sourceUrl.trim();
 
 	if (sourceUrl.length === 0) {
 		throw new Error('Match note source URL cannot be empty.');

--- a/src/services/match-url-parser.test.ts
+++ b/src/services/match-url-parser.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { parseMatchUrl, type MatchUrlParseErrorCode } from './match-url-parser';
+import type { MatchUrl } from '../types';
+
+void test('parseMatchUrl normalizes a valid HTTP(S) match URL', () => {
+	const value = expectParseSuccess(' HTTPS://EXAMPLE.COM/match ');
+
+	assert.deepEqual(value, {
+		sourceUrl: 'https://example.com/match',
+		sourceHost: 'example.com',
+	});
+});
+
+void test('parseMatchUrl rejects unsupported URL schemes', () => {
+	expectParseError('ftp://example.com/match', 'unsupported-url-scheme');
+});
+
+void test('parseMatchUrl rejects malformed raw whitespace and backslashes', async (t) => {
+	await t.test('embedded spaces', () => {
+		expectParseError('https://example.com/match 123', 'invalid-url');
+	});
+
+	await t.test('tab characters', () => {
+		expectParseError('https://example.com/match\t123', 'invalid-url');
+	});
+
+	await t.test('newline characters', () => {
+		expectParseError('https://example.com/match\n123', 'invalid-url');
+	});
+
+	await t.test('backslashes', () => {
+		expectParseError('https://\\example.com/match', 'invalid-url');
+	});
+});
+
+void test('parseMatchUrl rejects embedded username or password', async (t) => {
+	await t.test('empty userinfo delimiter', () => {
+		expectParseError('https://@example.com/match', 'unsupported-url-auth');
+	});
+
+	await t.test('empty userinfo with password delimiter', () => {
+		expectParseError('https://:@example.com/match', 'unsupported-url-auth');
+	});
+
+	await t.test('username auth', () => {
+		expectParseError('https://user@example.com/match', 'unsupported-url-auth');
+	});
+
+	await t.test('username and password auth', () => {
+		expectParseError('https://user:pass@example.com/match', 'unsupported-url-auth');
+	});
+});
+
+void test('parseMatchUrl accepts @ outside the URL authority', async (t) => {
+	await t.test('path segment', () => {
+		const value = expectParseSuccess('https://example.com/@club/match');
+
+		assert.equal(value.sourceUrl, 'https://example.com/@club/match');
+	});
+
+	await t.test('query string', () => {
+		const value = expectParseSuccess('https://example.com/match?team=@club');
+
+		assert.equal(value.sourceUrl, 'https://example.com/match?team=@club');
+	});
+});
+
+void test('parseMatchUrl preserves already encoded spaces', () => {
+	const value = expectParseSuccess('https://example.com/match%20123');
+
+	assert.deepEqual(value, {
+		sourceUrl: 'https://example.com/match%20123',
+		sourceHost: 'example.com',
+	});
+});
+
+function expectParseSuccess(input: string): MatchUrl {
+	const result = parseMatchUrl(input);
+
+	assert.equal(result.ok, true, `Expected parse success for ${JSON.stringify(input)}.`);
+
+	if (!result.ok) {
+		throw new Error(`Expected parse success for ${JSON.stringify(input)}.`);
+	}
+
+	return result.value;
+}
+
+function expectParseError(input: string, code: MatchUrlParseErrorCode): void {
+	const result = parseMatchUrl(input);
+
+	assert.equal(result.ok, false, `Expected parse error for ${JSON.stringify(input)}.`);
+
+	if (result.ok) {
+		throw new Error(`Expected parse error for ${JSON.stringify(input)}.`);
+	}
+
+	assert.equal(result.error.code, code);
+}

--- a/src/services/match-url-parser.ts
+++ b/src/services/match-url-parser.ts
@@ -58,7 +58,7 @@ export function parseMatchUrl(input: string): MatchUrlParseResult {
 		);
 	}
 
-	if (parsedUrl.username.length > 0 || parsedUrl.password.length > 0) {
+	if (containsUnsupportedAuth(trimmedInput, parsedUrl)) {
 		return createParseError(
 			'unsupported-url-auth',
 			'Match URL cannot include embedded username or password.',
@@ -109,4 +109,35 @@ function containsUnsupportedUrlCharacters(input: string): boolean {
 	}
 
 	return false;
+}
+
+function containsUnsupportedAuth(input: string, parsedUrl: URL): boolean {
+	if (parsedUrl.username.length > 0 || parsedUrl.password.length > 0) {
+		return true;
+	}
+
+	const authority = getRawAuthority(input);
+
+	return authority.includes('@');
+}
+
+function getRawAuthority(input: string): string {
+	const schemeSeparatorIndex = input.indexOf('//');
+
+	if (schemeSeparatorIndex === -1) {
+		return '';
+	}
+
+	const authorityStartIndex = schemeSeparatorIndex + 2;
+	let authorityEndIndex = input.length;
+
+	for (const separator of ['/', '?', '#']) {
+		const separatorIndex = input.indexOf(separator, authorityStartIndex);
+
+		if (separatorIndex !== -1 && separatorIndex < authorityEndIndex) {
+			authorityEndIndex = separatorIndex;
+		}
+	}
+
+	return input.slice(authorityStartIndex, authorityEndIndex);
 }

--- a/src/services/match-url-parser.ts
+++ b/src/services/match-url-parser.ts
@@ -94,7 +94,7 @@ function startsWithSupportedWebScheme(input: string): boolean {
 
 function containsUnsupportedUrlCharacters(input: string): boolean {
 	for (const character of input) {
-		if (character === '\\') {
+		if (character === '\\' || /\s/u.test(character)) {
 			return true;
 		}
 

--- a/src/services/match-url-parser.ts
+++ b/src/services/match-url-parser.ts
@@ -26,6 +26,13 @@ export function parseMatchUrl(input: string): MatchUrlParseResult {
 		return createParseError('empty-url', 'Match URL cannot be empty.');
 	}
 
+	if (containsUnsupportedUrlCharacters(trimmedInput)) {
+		return createParseError(
+			'invalid-url',
+			'Enter a valid match URL including http:// or https://.',
+		);
+	}
+
 	let parsedUrl: URL;
 
 	try {
@@ -83,4 +90,23 @@ function isSupportedUrlScheme(url: URL): boolean {
 
 function startsWithSupportedWebScheme(input: string): boolean {
 	return /^https?:\/\/[^/]/i.test(input);
+}
+
+function containsUnsupportedUrlCharacters(input: string): boolean {
+	for (const character of input) {
+		if (character === '\\') {
+			return true;
+		}
+
+		const codePoint = character.codePointAt(0);
+
+		if (
+			codePoint !== undefined &&
+			((codePoint >= 0x00 && codePoint <= 0x1f) || codePoint === 0x7f)
+		) {
+			return true;
+		}
+	}
+
+	return false;
 }

--- a/src/services/match-url-parser.ts
+++ b/src/services/match-url-parser.ts
@@ -1,0 +1,86 @@
+import type { MatchUrl } from '../types';
+
+export type MatchUrlParseErrorCode =
+	| 'empty-url'
+	| 'invalid-url'
+	| 'unsupported-url-scheme'
+	| 'unsupported-url-auth';
+
+export type MatchUrlParseResult =
+	| {
+			ok: true;
+			value: MatchUrl;
+	  }
+	| {
+			ok: false;
+			error: {
+				code: MatchUrlParseErrorCode;
+				message: string;
+			};
+	  };
+
+export function parseMatchUrl(input: string): MatchUrlParseResult {
+	const trimmedInput = input.trim();
+
+	if (trimmedInput.length === 0) {
+		return createParseError('empty-url', 'Match URL cannot be empty.');
+	}
+
+	let parsedUrl: URL;
+
+	try {
+		parsedUrl = new URL(trimmedInput);
+	} catch {
+		return createParseError(
+			'invalid-url',
+			'Enter a valid match URL including http:// or https://.',
+		);
+	}
+
+	if (!isSupportedUrlScheme(parsedUrl)) {
+		return createParseError(
+			'unsupported-url-scheme',
+			'Match URL must use http:// or https://.',
+		);
+	}
+
+	if (!startsWithSupportedWebScheme(trimmedInput)) {
+		return createParseError(
+			'invalid-url',
+			'Enter a valid match URL including http:// or https://.',
+		);
+	}
+
+	if (parsedUrl.username.length > 0 || parsedUrl.password.length > 0) {
+		return createParseError(
+			'unsupported-url-auth',
+			'Match URL cannot include embedded username or password.',
+		);
+	}
+
+	return {
+		ok: true,
+		value: {
+			sourceUrl: parsedUrl.href,
+			sourceHost: parsedUrl.host,
+		},
+	};
+}
+
+function createParseError(code: MatchUrlParseErrorCode, message: string): MatchUrlParseResult {
+	return {
+		ok: false,
+		error: {
+			code,
+			message,
+		},
+	};
+}
+
+function isSupportedUrlScheme(url: URL): boolean {
+	return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
+function startsWithSupportedWebScheme(input: string): boolean {
+	return /^https?:\/\/[^/]/i.test(input);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,11 @@ import { normalizePath } from 'obsidian';
 
 export const DEFAULT_MATCH_NOTES_FOLDER = 'Football notes/matches';
 
+export interface MatchUrl {
+	sourceUrl: string;
+	sourceHost: string;
+}
+
 export function normalizeMatchNotesFolder(folder: string): string {
 	const trimmedFolder = folder.trim();
 
@@ -25,7 +30,7 @@ function containsParentDirectorySegment(folder: string): boolean {
 }
 
 export interface MatchNoteInput {
-	sourceUrl: string;
+	source: MatchUrl;
 	destinationFolder: string;
 }
 


### PR DESCRIPTION
This pull request introduces a new URL parsing and normalization workflow for match notes, which improves validation and ensures that URLs are consistently structured. The changes include a new `MatchUrl` type, a robust URL parser with error handling, and updates to the schema and code to use parsed URLs instead of raw user input.

**URL parsing and normalization:**

* Added a new `MatchUrl` type (with `sourceUrl` and `sourceHost`) to represent normalized match URLs in `src/types.ts`.
* Implemented `parseMatchUrl` in `src/services/match-url-parser.ts` to validate and normalize URLs, with detailed error handling for empty, invalid, or unsupported URLs.

**Schema and interface updates:**

* Changed `MatchNoteInput` to use a `source: MatchUrl` property instead of a raw `sourceUrl` string in `src/types.ts`.
* Updated the match note draft creation logic in `src/services/match-note-template.ts` to use the normalized `source.sourceUrl` instead of the raw input.

**Documentation:**

* Clarified in `docs/match-note-schema.md` that `source_url` should be written from the plugin’s normalized URL parser output, not raw user input.

**Related Issues:**

* Resolve #19 