### PR TITLE
feat: add create match note from URL command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-		"test": "node --import jiti/register --test src/services/match-url-parser.test.ts",
+		"test": "node --import jiti/register --test src/services/match-url-parser.test.ts src/commands/create-match-note-from-url.test.ts",
 		"prepare": "husky",
 		"format": "prettier . --write",
 		"format:check": "prettier . --check",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-		"test": "node --import jiti/register --test src/services/match-url-parser.test.ts src/commands/create-match-note-from-url.test.ts",
+		"test": "node --import jiti/register --test src/services/match-url-parser.test.ts src/commands/create-match-note-from-url.test.ts src/ui/match-url-modal-state.test.ts",
 		"prepare": "husky",
 		"format": "prettier . --write",
 		"format:check": "prettier . --check",

--- a/src/commands/create-match-note-from-url.test.ts
+++ b/src/commands/create-match-note-from-url.test.ts
@@ -1,0 +1,220 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { type App, type TFile } from 'obsidian';
+
+import type FootballNotesPlugin from '../main';
+import { parseMatchUrl } from '../services/match-url-parser';
+import {
+	CREATE_MATCH_NOTE_FROM_URL_COMMAND_ID,
+	CREATE_MATCH_NOTE_FROM_URL_COMMAND_NAME,
+	createMatchNoteFromUrl,
+	registerCreateMatchNoteFromUrlCommand,
+} from './create-match-note-from-url';
+
+interface RegisteredCommand {
+	id: string;
+	name: string;
+	callback: () => Promise<void>;
+}
+
+void test('createMatchNoteFromUrl creates and opens a match note for a valid URL', async () => {
+	const calls: Array<unknown> = [];
+	const createdFile = createTestFile('New match note 2026-06-20 12-34-56.md');
+
+	const result = await createMatchNoteFromUrl(' HTTPS://EXAMPLE.COM/match ', {
+		destinationFolder: 'Football notes/matches',
+		createMatchNoteFile: async (input) => {
+			calls.push(['create', input]);
+			return createdFile;
+		},
+		openMatchNote: async (file) => {
+			calls.push(['open', file]);
+		},
+		showNotice: (message) => {
+			calls.push(['notice', message]);
+		},
+		logError: (message, error) => {
+			calls.push(['error', message, (error as Error).message]);
+		},
+	});
+
+	assert.equal(result, true);
+	assert.deepEqual(calls[0], [
+		'create',
+		{
+			source: {
+				sourceUrl: 'https://example.com/match',
+				sourceHost: 'example.com',
+			},
+			destinationFolder: 'Football notes/matches',
+		},
+	]);
+	assert.deepEqual(calls[1], ['open', createdFile]);
+	assert.deepEqual(calls[2], ['notice', `Created match note: ${createdFile.name}`]);
+	assert.equal(calls.length, 3);
+});
+
+void test('createMatchNoteFromUrl shows the parser error for invalid URLs', async () => {
+	const calls: Array<unknown> = [];
+
+	const result = await createMatchNoteFromUrl('ftp://example.com/match', {
+		destinationFolder: 'Football notes/matches',
+		createMatchNoteFile: async () => {
+			throw new Error('should not be called');
+		},
+		openMatchNote: async () => {
+			throw new Error('should not be called');
+		},
+		showNotice: (message) => {
+			calls.push(['notice', message]);
+		},
+		logError: (message, error) => {
+			calls.push(['error', message, (error as Error).message]);
+		},
+	});
+
+	assert.equal(result, false);
+	assert.deepEqual(calls, [['notice', 'Match URL must use http:// or https://.']]);
+});
+
+void test('createMatchNoteFromUrl reports creation failures', async () => {
+	const calls: Array<unknown> = [];
+
+	const result = await createMatchNoteFromUrl('https://example.com/match', {
+		destinationFolder: 'Football notes/matches',
+		createMatchNoteFile: async () => {
+			throw new Error('disk full');
+		},
+		openMatchNote: async () => {
+			throw new Error('should not be called');
+		},
+		showNotice: (message) => {
+			calls.push(['notice', message]);
+		},
+		logError: (message, error) => {
+			calls.push(['error', message, (error as Error).message]);
+		},
+	});
+
+	assert.equal(result, false);
+	assert.deepEqual(calls, [
+		['error', 'Failed to create match note from URL.', 'disk full'],
+		['notice', 'Could not create match note. See console for details.'],
+	]);
+});
+
+void test('createMatchNoteFromUrl reports open failures without hiding the created note', async () => {
+	const calls: Array<unknown> = [];
+	const createdFile = createTestFile('New match note 2026-06-20 12-34-56.md');
+
+	const result = await createMatchNoteFromUrl('https://example.com/match', {
+		destinationFolder: 'Football notes/matches',
+		createMatchNoteFile: async () => createdFile,
+		openMatchNote: async () => {
+			throw new Error('workspace unavailable');
+		},
+		showNotice: (message) => {
+			calls.push(['notice', message]);
+		},
+		logError: (message, error) => {
+			calls.push(['error', message, (error as Error).message]);
+		},
+	});
+
+	assert.equal(result, true);
+	assert.deepEqual(calls, [
+		['error', 'Created match note, but could not open it.', 'workspace unavailable'],
+		['notice', `Created match note: ${createdFile.name}, but could not open it automatically.`],
+	]);
+});
+
+void test('registerCreateMatchNoteFromUrlCommand wires the command entrypoint', async () => {
+	let capturedCommand: RegisteredCommand | undefined;
+	let createModalCalls = 0;
+	let openCalls = 0;
+
+	const plugin = {
+		addCommand(command: RegisteredCommand) {
+			capturedCommand = command;
+			return command;
+		},
+		app: {} as App,
+		settings: {
+			notesFolder: 'Football notes/matches',
+		},
+	} as unknown as FootballNotesPlugin;
+
+	registerCreateMatchNoteFromUrlCommand(plugin, {
+		createModal: (_app, onSubmit) => {
+			createModalCalls += 1;
+			assert.equal(typeof onSubmit, 'function');
+
+			return {
+				open() {
+					openCalls += 1;
+				},
+			};
+		},
+	});
+
+	assert.ok(capturedCommand);
+	assert.equal(capturedCommand?.id, CREATE_MATCH_NOTE_FROM_URL_COMMAND_ID);
+	assert.equal(capturedCommand?.name, CREATE_MATCH_NOTE_FROM_URL_COMMAND_NAME);
+
+	await capturedCommand?.callback();
+
+	assert.equal(createModalCalls, 1);
+	assert.equal(openCalls, 1);
+});
+
+void test('registerCreateMatchNoteFromUrlCommand reports modal setup failures', async () => {
+	const calls: Array<unknown> = [];
+	let capturedCommand: RegisteredCommand | undefined;
+
+	const plugin = {
+		addCommand(command: RegisteredCommand) {
+			capturedCommand = command;
+			return command;
+		},
+		app: {} as App,
+		settings: {
+			notesFolder: 'Football notes/matches',
+		},
+	} as unknown as FootballNotesPlugin;
+
+	registerCreateMatchNoteFromUrlCommand(plugin, {
+		createModal: async () => {
+			throw new Error('modal unavailable');
+		},
+		showNotice: (message) => {
+			calls.push(['notice', message]);
+		},
+		logError: (message, error) => {
+			calls.push(['error', message, (error as Error).message]);
+		},
+	});
+
+	await capturedCommand?.callback();
+
+	assert.deepEqual(calls, [
+		['error', 'Failed to open match note dialog.', 'modal unavailable'],
+		['notice', 'Could not open match note dialog. See console for details.'],
+	]);
+});
+
+void test('parseMatchUrl keeps the workflow parser behavior intact', () => {
+	assert.equal(parseMatchUrl('https://example.com/match').ok, true);
+});
+
+function createTestFile(name: string): TFile {
+	return {
+		vault: undefined as never,
+		path: `Football notes/matches/${name}`,
+		name,
+		parent: null,
+		stat: undefined as never,
+		basename: name.replace(/\.md$/u, ''),
+		extension: 'md',
+	};
+}

--- a/src/commands/create-match-note-from-url.ts
+++ b/src/commands/create-match-note-from-url.ts
@@ -1,0 +1,120 @@
+import { Notice, type App, type TFile } from 'obsidian';
+
+import type FootballNotesPlugin from '../main';
+import { createMatchNoteFile } from '../services/match-note-files';
+import { parseMatchUrl, type MatchUrlParseResult } from '../services/match-url-parser';
+import type { MatchNoteInput } from '../types';
+import type { MatchUrlSubmitHandler } from '../ui/match-url-modal';
+
+export const CREATE_MATCH_NOTE_FROM_URL_COMMAND_ID = 'create-match-note-from-url';
+export const CREATE_MATCH_NOTE_FROM_URL_COMMAND_NAME = 'Create match note from URL';
+
+export interface CreateMatchNoteFromUrlWorkflowDependencies {
+	destinationFolder: string;
+	parseMatchUrl?: (input: string) => MatchUrlParseResult;
+	createMatchNoteFile: (input: MatchNoteInput) => Promise<TFile>;
+	openMatchNote: (file: TFile) => Promise<void>;
+	showNotice: (message: string) => void;
+	logError: (message: string, error: unknown) => void;
+}
+
+export interface CreateMatchNoteFromUrlCommandDependencies {
+	createModal?: (
+		app: App,
+		onSubmit: MatchUrlSubmitHandler,
+	) => MatchUrlModalLike | Promise<MatchUrlModalLike>;
+	showNotice?: (message: string) => void;
+	logError?: (message: string, error: unknown) => void;
+}
+
+export interface MatchUrlModalLike {
+	open(): void;
+}
+
+export function registerCreateMatchNoteFromUrlCommand(
+	plugin: FootballNotesPlugin,
+	dependencies: Partial<CreateMatchNoteFromUrlCommandDependencies> = {},
+): void {
+	const showNotice = dependencies.showNotice ?? ((message: string) => new Notice(message));
+	const logError =
+		dependencies.logError ??
+		((message: string, error: unknown) => console.error(message, error));
+
+	plugin.addCommand({
+		id: CREATE_MATCH_NOTE_FROM_URL_COMMAND_ID,
+		name: CREATE_MATCH_NOTE_FROM_URL_COMMAND_NAME,
+		callback: async () => {
+			try {
+				const modal = dependencies.createModal ?? createDefaultMatchUrlModal;
+
+				const createdModal = await modal(plugin.app, async (input) => {
+					return await createMatchNoteFromUrl(input, {
+						destinationFolder: plugin.settings.notesFolder,
+						createMatchNoteFile: (matchNoteInput) =>
+							createMatchNoteFile(plugin.app.vault, matchNoteInput),
+						openMatchNote: async (file) => {
+							await plugin.app.workspace.getLeaf(false).openFile(file);
+						},
+						showNotice,
+						logError,
+					});
+				});
+
+				createdModal.open();
+			} catch (error) {
+				logError('Failed to open match note dialog.', error);
+				showNotice('Could not open match note dialog. See console for details.');
+			}
+		},
+	});
+}
+
+async function createDefaultMatchUrlModal(
+	app: App,
+	onSubmit: MatchUrlSubmitHandler,
+): Promise<MatchUrlModalLike> {
+	const { MatchUrlModal } = await import('../ui/match-url-modal');
+	const modal = new MatchUrlModal(app, onSubmit);
+
+	return {
+		open: () => {
+			modal.open();
+		},
+	};
+}
+
+export async function createMatchNoteFromUrl(
+	input: string,
+	dependencies: CreateMatchNoteFromUrlWorkflowDependencies,
+): Promise<boolean> {
+	const parseResult = (dependencies.parseMatchUrl ?? parseMatchUrl)(input);
+
+	if (!parseResult.ok) {
+		dependencies.showNotice(parseResult.error.message);
+		return false;
+	}
+
+	try {
+		const createdFile = await dependencies.createMatchNoteFile({
+			source: parseResult.value,
+			destinationFolder: dependencies.destinationFolder,
+		});
+
+		try {
+			await dependencies.openMatchNote(createdFile);
+		} catch (error) {
+			dependencies.logError('Created match note, but could not open it.', error);
+			dependencies.showNotice(
+				`Created match note: ${createdFile.name}, but could not open it automatically.`,
+			);
+			return true;
+		}
+
+		dependencies.showNotice(`Created match note: ${createdFile.name}`);
+		return true;
+	} catch (error) {
+		dependencies.logError('Failed to create match note from URL.', error);
+		dependencies.showNotice('Could not create match note. See console for details.');
+		return false;
+	}
+}

--- a/src/commands/create-match-note-from-url.ts
+++ b/src/commands/create-match-note-from-url.ts
@@ -1,4 +1,4 @@
-import { Notice, type App, type TFile } from 'obsidian';
+import type { App, TFile } from 'obsidian';
 
 import type FootballNotesPlugin from '../main';
 import { createMatchNoteFile } from '../services/match-note-files';
@@ -35,10 +35,8 @@ export function registerCreateMatchNoteFromUrlCommand(
 	plugin: FootballNotesPlugin,
 	dependencies: Partial<CreateMatchNoteFromUrlCommandDependencies> = {},
 ): void {
-	const showNotice = dependencies.showNotice ?? ((message: string) => new Notice(message));
-	const logError =
-		dependencies.logError ??
-		((message: string, error: unknown) => console.error(message, error));
+	const showNotice = dependencies.showNotice ?? createDefaultShowNotice();
+	const logError = dependencies.logError ?? defaultLogError;
 
 	plugin.addCommand({
 		id: CREATE_MATCH_NOTE_FROM_URL_COMMAND_ID,
@@ -67,6 +65,22 @@ export function registerCreateMatchNoteFromUrlCommand(
 			}
 		},
 	});
+}
+
+function createDefaultShowNotice(): (message: string) => void {
+	return (message: string) => {
+		void import('obsidian')
+			.then(({ Notice }) => {
+				new Notice(message);
+			})
+			.catch((error) => {
+				console.error('Could not show notice.', error, message);
+			});
+	};
+}
+
+function defaultLogError(message: string, error: unknown): void {
+	console.error(message, error);
 }
 
 async function createDefaultMatchUrlModal(

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,6 @@
+import type FootballNotesPlugin from '../main';
+import { registerCreateMatchNoteFromUrlCommand } from './create-match-note-from-url';
+
+export function registerCommands(plugin: FootballNotesPlugin): void {
+	registerCreateMatchNoteFromUrlCommand(plugin);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { Plugin } from 'obsidian';
+import { registerCommands } from './commands';
 import { DEFAULT_SETTINGS, FootballNotesSettings, FootballNotesSettingTab } from './settings';
 import { normalizeMatchNotesFolder } from './types';
 
@@ -7,6 +8,7 @@ export default class FootballNotesPlugin extends Plugin {
 
 	async onload() {
 		await this.loadSettings();
+		registerCommands(this);
 		this.addSettingTab(new FootballNotesSettingTab(this.app, this));
 	}
 

--- a/src/ui/match-url-modal-state.test.ts
+++ b/src/ui/match-url-modal-state.test.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { canCloseMatchUrlModal } from './match-url-modal-state';
+
+void test('canCloseMatchUrlModal blocks dismissal while submitting', () => {
+	assert.equal(canCloseMatchUrlModal(true), false);
+	assert.equal(canCloseMatchUrlModal(false), true);
+});

--- a/src/ui/match-url-modal-state.ts
+++ b/src/ui/match-url-modal-state.ts
@@ -1,0 +1,3 @@
+export function canCloseMatchUrlModal(isSubmitting: boolean): boolean {
+	return !isSubmitting;
+}

--- a/src/ui/match-url-modal.ts
+++ b/src/ui/match-url-modal.ts
@@ -28,9 +28,18 @@ export class MatchUrlModal extends Modal {
 		});
 
 		const inputContainer = contentEl.createDiv({ cls: 'football-notes-match-url-input' });
+		const inputLabel = inputContainer.createEl('label', {
+			text: 'Match URL',
+		});
+		inputLabel.addClass('football-notes-match-url-label');
+		inputLabel.id = 'football-notes-match-url-label';
+		inputLabel.setAttr('for', 'football-notes-match-url-input');
+
 		this.matchUrlInput = new TextComponent(inputContainer);
+		this.matchUrlInput.inputEl.id = 'football-notes-match-url-input';
 		this.matchUrlInput.setPlaceholder('https://example.com/match/123');
 		this.matchUrlInput.setValue('');
+		this.matchUrlInput.inputEl.setAttr('aria-labelledby', inputLabel.id);
 		this.matchUrlInput.inputEl.focus();
 		this.matchUrlInput.inputEl.select();
 

--- a/src/ui/match-url-modal.ts
+++ b/src/ui/match-url-modal.ts
@@ -1,0 +1,87 @@
+import { App, ButtonComponent, Modal, TextComponent } from 'obsidian';
+
+export type MatchUrlSubmitHandler = (value: string) => Promise<boolean>;
+
+export class MatchUrlModal extends Modal {
+	private readonly onSubmit: MatchUrlSubmitHandler;
+	private matchUrlInput: TextComponent | undefined;
+	private createButton: ButtonComponent | undefined;
+	private keydownHandler: ((event: KeyboardEvent) => void) | undefined;
+	private isSubmitting = false;
+
+	constructor(app: App, onSubmit: MatchUrlSubmitHandler) {
+		super(app);
+		this.onSubmit = onSubmit;
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+
+		contentEl.empty();
+		this.setTitle('Create match note from URL');
+
+		contentEl.createEl('p', {
+			text: 'Paste a football match URL to create a new match note.',
+		});
+
+		const inputContainer = contentEl.createDiv({ cls: 'football-notes-match-url-input' });
+		this.matchUrlInput = new TextComponent(inputContainer);
+		this.matchUrlInput.setPlaceholder('https://example.com/match/123');
+		this.matchUrlInput.setValue('');
+		this.matchUrlInput.inputEl.focus();
+		this.matchUrlInput.inputEl.select();
+
+		this.keydownHandler = (event: KeyboardEvent) => {
+			if (event.key !== 'Enter' || event.isComposing) {
+				return;
+			}
+
+			event.preventDefault();
+			void this.submit();
+		};
+		this.matchUrlInput.inputEl.addEventListener('keydown', this.keydownHandler);
+
+		const buttonRow = contentEl.createDiv({ cls: 'modal-button-container' });
+		new ButtonComponent(buttonRow).setButtonText('Cancel').onClick(() => this.close());
+
+		this.createButton = new ButtonComponent(buttonRow);
+		this.createButton.setButtonText('Create note');
+		this.createButton.setCta();
+		this.createButton.onClick(() => {
+			void this.submit();
+		});
+	}
+
+	onClose(): void {
+		if (this.matchUrlInput && this.keydownHandler) {
+			this.matchUrlInput.inputEl.removeEventListener('keydown', this.keydownHandler);
+		}
+
+		this.keydownHandler = undefined;
+		this.contentEl.empty();
+	}
+
+	private async submit(): Promise<void> {
+		if (
+			this.isSubmitting ||
+			this.matchUrlInput === undefined ||
+			this.createButton === undefined
+		) {
+			return;
+		}
+
+		this.isSubmitting = true;
+		this.createButton.setDisabled(true);
+
+		try {
+			const shouldClose = await this.onSubmit(this.matchUrlInput.getValue());
+
+			if (shouldClose) {
+				this.close();
+			}
+		} finally {
+			this.isSubmitting = false;
+			this.createButton.setDisabled(false);
+		}
+	}
+}

--- a/src/ui/match-url-modal.ts
+++ b/src/ui/match-url-modal.ts
@@ -1,10 +1,13 @@
 import { App, ButtonComponent, Modal, TextComponent } from 'obsidian';
 
+import { canCloseMatchUrlModal } from './match-url-modal-state';
+
 export type MatchUrlSubmitHandler = (value: string) => Promise<boolean>;
 
 export class MatchUrlModal extends Modal {
 	private readonly onSubmit: MatchUrlSubmitHandler;
 	private matchUrlInput: TextComponent | undefined;
+	private cancelButton: ButtonComponent | undefined;
 	private createButton: ButtonComponent | undefined;
 	private keydownHandler: ((event: KeyboardEvent) => void) | undefined;
 	private isSubmitting = false;
@@ -42,7 +45,9 @@ export class MatchUrlModal extends Modal {
 		this.matchUrlInput.inputEl.addEventListener('keydown', this.keydownHandler);
 
 		const buttonRow = contentEl.createDiv({ cls: 'modal-button-container' });
-		new ButtonComponent(buttonRow).setButtonText('Cancel').onClick(() => this.close());
+		this.cancelButton = new ButtonComponent(buttonRow);
+		this.cancelButton.setButtonText('Cancel');
+		this.cancelButton.onClick(() => this.close());
 
 		this.createButton = new ButtonComponent(buttonRow);
 		this.createButton.setButtonText('Create note');
@@ -61,6 +66,14 @@ export class MatchUrlModal extends Modal {
 		this.contentEl.empty();
 	}
 
+	close(): void {
+		if (!canCloseMatchUrlModal(this.isSubmitting)) {
+			return;
+		}
+
+		super.close();
+	}
+
 	private async submit(): Promise<void> {
 		if (
 			this.isSubmitting ||
@@ -71,17 +84,23 @@ export class MatchUrlModal extends Modal {
 		}
 
 		this.isSubmitting = true;
-		this.createButton.setDisabled(true);
+		this.setButtonsDisabled(true);
+		let shouldClose = false;
 
 		try {
-			const shouldClose = await this.onSubmit(this.matchUrlInput.getValue());
-
-			if (shouldClose) {
-				this.close();
-			}
+			shouldClose = await this.onSubmit(this.matchUrlInput.getValue());
 		} finally {
 			this.isSubmitting = false;
-			this.createButton.setDisabled(false);
+			this.setButtonsDisabled(false);
 		}
+
+		if (shouldClose) {
+			super.close();
+		}
+	}
+
+	private setButtonsDisabled(disabled: boolean): void {
+		this.cancelButton?.setDisabled(disabled);
+		this.createButton?.setDisabled(disabled);
 	}
 }


### PR DESCRIPTION
This pull request introduces a new "Create match note from URL" workflow, including its command registration, modal UI, and comprehensive tests. The workflow allows users to paste a football match URL and automatically generate a match note. The implementation is modular, testable, and integrates with the plugin's command system. The most important changes are grouped below.

**Feature: Create Match Note from URL Workflow**

* Added `create-match-note-from-url.ts` implementing the workflow, including error handling, dependency injection, and command registration logic.
* Registered the new command in the plugin lifecycle via `registerCommands` in `main.ts` and `commands/index.ts`. [[1]](diffhunk://#diff-a6a1db61476382a80351bf0b40126b3cfca87878293a3fca70dfe04367f4a11fR1-R6) [[2]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR2) [[3]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR11)

**User Interface: Match URL Modal**

* Implemented `MatchUrlModal` in `match-url-modal.ts`, providing a modal dialog for users to input match URLs, with proper submission, validation, and button state handling.
* Added `canCloseMatchUrlModal` utility and corresponding test to control modal dismissal during submission. [[1]](diffhunk://#diff-a206f59fe90590fc0bf392a182de3f958ecae4635ffce7ac8578c3bd4c7405cfR1-R3) [[2]](diffhunk://#diff-a63d1950620ee0b54468bb60fe50e3d0a2bfab244de443b56c09996fc19a901eR1-R9)

**Testing and Build Improvements**

* Added comprehensive tests for the new workflow, command registration, and modal state logic. [[1]](diffhunk://#diff-efdb49f30680992431728e73450601a973b9bf97d7d65a2b01076596dac2675eR1-R220) [[2]](diffhunk://#diff-a63d1950620ee0b54468bb60fe50e3d0a2bfab244de443b56c09996fc19a901eR1-R9)
* Updated the `test` script in `package.json` to include new test files for full coverage.

**Related Issues:**

* Resolve #21 