### PR TITLE
fix: harden match note settings and file creation retries

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-		"test": "node --import jiti/register --test src/services/match-url-parser.test.ts src/commands/create-match-note-from-url.test.ts src/ui/match-url-modal-state.test.ts",
+		"test": "node --import jiti/register --test src/services/match-url-parser.test.ts src/commands/create-match-note-from-url.test.ts src/ui/match-url-modal-state.test.ts src/settings.test.ts src/services/match-note-files.test.ts",
 		"prepare": "husky",
 		"format": "prettier . --write",
 		"format:check": "prettier . --check",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { Plugin } from 'obsidian';
 import { registerCommands } from './commands';
-import { DEFAULT_SETTINGS, FootballNotesSettings, FootballNotesSettingTab } from './settings';
+import { FootballNotesSettingTab } from './settings';
+import { type FootballNotesSettings, hydrateLoadedSettings } from './settings-data';
 import { normalizeMatchNotesFolder } from './types';
 
 export default class FootballNotesPlugin extends Plugin {
@@ -13,18 +14,11 @@ export default class FootballNotesPlugin extends Plugin {
 	}
 
 	async loadSettings() {
-		const loadedSettings = (await this.loadData()) as Partial<FootballNotesSettings>;
-		const notesFolder = normalizeMatchNotesFolder(
-			loadedSettings?.notesFolder ?? DEFAULT_SETTINGS.notesFolder,
-		);
-		const shouldPersistNormalizedFolder =
-			loadedSettings?.notesFolder !== undefined && loadedSettings.notesFolder !== notesFolder;
+		const loadedSettings = hydrateLoadedSettings(await this.loadData());
 
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, loadedSettings, {
-			notesFolder,
-		});
+		this.settings = loadedSettings.settings;
 
-		if (shouldPersistNormalizedFolder) {
+		if (loadedSettings.shouldPersistNormalizedFolder) {
 			await this.saveSettings();
 		}
 	}

--- a/src/path-utils.ts
+++ b/src/path-utils.ts
@@ -1,0 +1,19 @@
+export function normalizeVaultPath(path: string): string {
+	const trimmedPath = path.trim();
+
+	if (trimmedPath.length === 0) {
+		return '';
+	}
+
+	const segments: string[] = [];
+
+	for (const segment of trimmedPath.split(/[\\/]+/)) {
+		if (segment.length === 0 || segment === '.') {
+			continue;
+		}
+
+		segments.push(segment);
+	}
+
+	return segments.join('/');
+}

--- a/src/services/match-note-files.test.ts
+++ b/src/services/match-note-files.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { Vault } from 'obsidian';
+
+import { createMatchNoteFile } from './match-note-files';
+import { createMatchNotePath } from './match-note-paths';
+import type { MatchNoteInput } from '../types';
+
+void test('createMatchNoteFile retries until it finds a free path', async () => {
+	const fixedDate = new Date('2026-06-20T12:34:56Z');
+	const originalDate = globalThis.Date;
+	const vault = new FakeVault();
+	const folder = 'Football notes/matches';
+	const firstCandidate = createMatchNotePath(folder, 'New match note', fixedDate, 1);
+	const secondCandidate = createMatchNotePath(folder, 'New match note', fixedDate, 2);
+
+	vault.seedFile(firstCandidate);
+	vault.seedFile(secondCandidate);
+
+	await withFixedDate(fixedDate, async () => {
+		const result = await createMatchNoteFile(vault as unknown as Vault, createInput(folder));
+
+		assert.equal(result.path, createMatchNotePath(folder, 'New match note', fixedDate, 3));
+		assert.deepEqual(vault.createFolderCalls, ['Football notes', 'Football notes/matches']);
+		assert.deepEqual(vault.createCalls, [
+			{
+				path: createMatchNotePath(folder, 'New match note', fixedDate, 3),
+				content: vault.createdContent,
+			},
+		]);
+	});
+
+	assert.equal(globalThis.Date, originalDate);
+});
+
+void test('createMatchNoteFile stops after 100 failed attempts', async () => {
+	const fixedDate = new Date('2026-06-20T12:34:56Z');
+	const vault = new FakeVault();
+	const folder = 'Football notes/matches';
+	const expectedPaths = Array.from({ length: 100 }, (_, index) =>
+		createMatchNotePath(folder, 'New match note', fixedDate, index + 1),
+	);
+
+	for (const path of expectedPaths) {
+		vault.seedFile(path);
+	}
+
+	await withFixedDate(fixedDate, async () => {
+		await assert.rejects(
+			createMatchNoteFile(vault as unknown as Vault, createInput(folder)),
+			/Could not create match note "New match note" in "Football notes\/matches" after 100 attempts\./i,
+		);
+	});
+});
+
+function createInput(destinationFolder: string): MatchNoteInput {
+	return {
+		source: {
+			sourceUrl: 'https://example.com/match',
+			sourceHost: 'example.com',
+		},
+		destinationFolder,
+	};
+}
+
+async function withFixedDate<T>(fixedDate: Date, callback: () => Promise<T>): Promise<T> {
+	const originalDate = globalThis.Date;
+
+	class MockDate extends originalDate {
+		constructor(...args: [] | [string | number | Date]) {
+			if (args.length === 0) {
+				super(fixedDate.getTime());
+				return;
+			}
+
+			super(...args);
+		}
+
+		static now(): number {
+			return fixedDate.getTime();
+		}
+	}
+
+	globalThis.Date = MockDate as unknown as DateConstructor;
+
+	try {
+		return await callback();
+	} finally {
+		globalThis.Date = originalDate;
+	}
+}
+
+class FakeVault {
+	private files = new Map<string, FakeVaultEntry>();
+
+	createCalls: Array<{ path: string; content: string }> = [];
+
+	createFolderCalls: string[] = [];
+
+	createdContent = '';
+
+	seedFile(path: string): void {
+		this.files.set(path, createFakeFile(path));
+	}
+
+	getAbstractFileByPath(path: string): FakeVaultEntry | null {
+		return this.files.get(path) ?? null;
+	}
+
+	async create(path: string, content: string): Promise<FakeVaultEntry> {
+		this.createCalls.push({ path, content });
+		this.createdContent = content;
+
+		if (this.files.has(path)) {
+			throw new Error(`File already exists: ${path}`);
+		}
+
+		const file = createFakeFile(path);
+		this.files.set(path, file);
+		return file;
+	}
+
+	async createFolder(path: string): Promise<void> {
+		this.createFolderCalls.push(path);
+
+		if (this.files.has(path)) {
+			throw new Error(`File already exists: ${path}`);
+		}
+
+		this.files.set(path, createFakeFolder(path));
+	}
+}
+
+type FakeVaultEntry = FakeFile | FakeFolder;
+
+interface FakeFile {
+	path: string;
+	name: string;
+}
+
+interface FakeFolder {
+	path: string;
+	name: string;
+	children: Array<unknown>;
+}
+
+function createFakeFile(path: string): FakeFile {
+	return {
+		path,
+		name: path.slice(path.lastIndexOf('/') + 1),
+	};
+}
+
+function createFakeFolder(path: string): FakeFolder {
+	return {
+		path,
+		name: path.slice(path.lastIndexOf('/') + 1),
+		children: [],
+	};
+}

--- a/src/services/match-note-files.test.ts
+++ b/src/services/match-note-files.test.ts
@@ -34,6 +34,33 @@ void test('createMatchNoteFile retries until it finds a free path', async () => 
 	assert.equal(globalThis.Date, originalDate);
 });
 
+void test('createMatchNoteFile retries when create races with an already existing file', async () => {
+	const fixedDate = new Date('2026-06-20T12:34:56Z');
+	const vault = new FakeVault();
+	const folder = 'Football notes/matches';
+	const firstCandidate = createMatchNotePath(folder, 'New match note', fixedDate, 1);
+	const secondCandidate = createMatchNotePath(folder, 'New match note', fixedDate, 2);
+
+	vault.failCreateOnce(firstCandidate);
+
+	await withFixedDate(fixedDate, async () => {
+		const result = await createMatchNoteFile(vault as unknown as Vault, createInput(folder));
+
+		assert.equal(result.path, secondCandidate);
+		assert.deepEqual(vault.createFolderCalls, ['Football notes', 'Football notes/matches']);
+		assert.deepEqual(vault.createCalls, [
+			{
+				path: firstCandidate,
+				content: vault.createdContent,
+			},
+			{
+				path: secondCandidate,
+				content: vault.createdContent,
+			},
+		]);
+	});
+});
+
 void test('createMatchNoteFile stops after 100 failed attempts', async () => {
 	const fixedDate = new Date('2026-06-20T12:34:56Z');
 	const vault = new FakeVault();
@@ -93,6 +120,7 @@ async function withFixedDate<T>(fixedDate: Date, callback: () => Promise<T>): Pr
 
 class FakeVault {
 	private files = new Map<string, FakeVaultEntry>();
+	private createFailures = new Set<string>();
 
 	createCalls: Array<{ path: string; content: string }> = [];
 
@@ -104,6 +132,10 @@ class FakeVault {
 		this.files.set(path, createFakeFile(path));
 	}
 
+	failCreateOnce(path: string): void {
+		this.createFailures.add(path);
+	}
+
 	getAbstractFileByPath(path: string): FakeVaultEntry | null {
 		return this.files.get(path) ?? null;
 	}
@@ -111,6 +143,11 @@ class FakeVault {
 	async create(path: string, content: string): Promise<FakeVaultEntry> {
 		this.createCalls.push({ path, content });
 		this.createdContent = content;
+
+		if (this.createFailures.has(path)) {
+			this.createFailures.delete(path);
+			throw new Error(`File already exists: ${path}`);
+		}
 
 		if (this.files.has(path)) {
 			throw new Error(`File already exists: ${path}`);

--- a/src/services/match-note-files.ts
+++ b/src/services/match-note-files.ts
@@ -1,8 +1,10 @@
-import { TFile, TFolder, Vault } from 'obsidian';
+import type { TFile, Vault } from 'obsidian';
 
 import type { MatchNoteInput } from '../types';
 import { createMatchNotePath, getFolderCreationChain } from './match-note-paths';
 import { createMatchNoteDraft } from './match-note-template';
+
+const MAX_MATCH_NOTE_CREATE_ATTEMPTS = 100;
 
 export async function createMatchNoteFile(vault: Vault, input: MatchNoteInput): Promise<TFile> {
 	const draft = createMatchNoteDraft(input);
@@ -20,13 +22,10 @@ async function createMatchNoteFileWithRetry(
 	now: Date,
 	content: string,
 ): Promise<TFile> {
-	let attempt = 1;
-
-	for (;;) {
+	for (let attempt = 1; attempt <= MAX_MATCH_NOTE_CREATE_ATTEMPTS; attempt += 1) {
 		const candidatePath = createMatchNotePath(folder, title, now, attempt);
 
 		if (vault.getAbstractFileByPath(candidatePath) !== null) {
-			attempt += 1;
 			continue;
 		}
 
@@ -37,13 +36,22 @@ async function createMatchNoteFileWithRetry(
 				vault.getAbstractFileByPath(candidatePath) !== null ||
 				isAlreadyExistsError(error)
 			) {
-				attempt += 1;
+				if (attempt === MAX_MATCH_NOTE_CREATE_ATTEMPTS) {
+					throw createMatchNoteRetryLimitError(
+						title,
+						folder,
+						MAX_MATCH_NOTE_CREATE_ATTEMPTS,
+					);
+				}
+
 				continue;
 			}
 
 			throw error;
 		}
 	}
+
+	throw createMatchNoteRetryLimitError(title, folder, MAX_MATCH_NOTE_CREATE_ATTEMPTS);
 }
 
 async function ensureFolderExists(vault: Vault, folder: string): Promise<void> {
@@ -56,7 +64,7 @@ async function ensureFolderExists(vault: Vault, folder: string): Promise<void> {
 			} catch (error) {
 				const createdFolder = vault.getAbstractFileByPath(folderPath);
 
-				if (createdFolder instanceof TFolder) {
+				if (isFolderLike(createdFolder)) {
 					continue;
 				}
 
@@ -75,7 +83,7 @@ async function ensureFolderExists(vault: Vault, folder: string): Promise<void> {
 			continue;
 		}
 
-		if (!(existingFile instanceof TFolder)) {
+		if (!isFolderLike(existingFile)) {
 			throw new Error(
 				`Cannot create match note folder because "${folderPath}" already exists as a file.`,
 			);
@@ -85,4 +93,14 @@ async function ensureFolderExists(vault: Vault, folder: string): Promise<void> {
 
 function isAlreadyExistsError(error: unknown): boolean {
 	return error instanceof Error && error.message.toLowerCase().includes('already exists');
+}
+
+function isFolderLike(value: unknown): value is { children: unknown[] } {
+	return typeof value === 'object' && value !== null && 'children' in value;
+}
+
+function createMatchNoteRetryLimitError(title: string, folder: string, attempts: number): Error {
+	return new Error(
+		`Could not create match note "${title}" in "${folder}" after ${attempts} attempts.`,
+	);
 }

--- a/src/services/match-note-paths.ts
+++ b/src/services/match-note-paths.ts
@@ -1,6 +1,5 @@
-import { normalizePath } from 'obsidian';
-
 import { normalizeMatchNotesFolder } from '../types';
+import { normalizeVaultPath } from '../path-utils';
 
 const MATCH_NOTE_FILE_EXTENSION = '.md';
 
@@ -44,7 +43,7 @@ export function createMatchNoteCandidateFilename(
 export function createMatchNotePath(folder: string, title: string, now: Date, attempt = 1): string {
 	const normalizedFolder = normalizeMatchNotesFolder(folder);
 
-	return normalizePath(
+	return normalizeVaultPath(
 		`${normalizedFolder}/${createMatchNoteCandidateFilename(title, now, attempt)}`,
 	);
 }

--- a/src/settings-data.ts
+++ b/src/settings-data.ts
@@ -14,17 +14,18 @@ export interface HydratedLoadedSettings {
 }
 
 export function hydrateLoadedSettings(loaded: unknown): HydratedLoadedSettings {
-	const loadedSettings = isRecord(loaded) ? loaded : {};
+	const loadedIsRecord = isRecord(loaded);
+	const loadedSettings = loadedIsRecord ? loaded : {};
 	const rawNotesFolder =
 		typeof loadedSettings.notesFolder === 'string'
 			? loadedSettings.notesFolder
 			: DEFAULT_SETTINGS.notesFolder;
 	const notesFolder = normalizeMatchNotesFolder(rawNotesFolder);
 	const shouldPersistNormalizedFolder =
-		loadedSettings.notesFolder === undefined
-			? false
-			: typeof loadedSettings.notesFolder !== 'string' ||
-				loadedSettings.notesFolder !== notesFolder;
+		!loadedIsRecord ||
+		(loadedSettings.notesFolder !== undefined &&
+			(typeof loadedSettings.notesFolder !== 'string' ||
+				loadedSettings.notesFolder !== notesFolder));
 
 	return {
 		settings: {

--- a/src/settings-data.ts
+++ b/src/settings-data.ts
@@ -1,0 +1,39 @@
+import { DEFAULT_MATCH_NOTES_FOLDER, normalizeMatchNotesFolder } from './types';
+
+export interface FootballNotesSettings {
+	notesFolder: string;
+}
+
+export const DEFAULT_SETTINGS: FootballNotesSettings = {
+	notesFolder: DEFAULT_MATCH_NOTES_FOLDER,
+};
+
+export interface HydratedLoadedSettings {
+	settings: FootballNotesSettings;
+	shouldPersistNormalizedFolder: boolean;
+}
+
+export function hydrateLoadedSettings(loaded: unknown): HydratedLoadedSettings {
+	const loadedSettings = isRecord(loaded) ? loaded : {};
+	const rawNotesFolder =
+		typeof loadedSettings.notesFolder === 'string'
+			? loadedSettings.notesFolder
+			: DEFAULT_SETTINGS.notesFolder;
+	const notesFolder = normalizeMatchNotesFolder(rawNotesFolder);
+	const shouldPersistNormalizedFolder =
+		loadedSettings.notesFolder === undefined
+			? false
+			: typeof loadedSettings.notesFolder !== 'string' ||
+				loadedSettings.notesFolder !== notesFolder;
+
+	return {
+		settings: {
+			notesFolder,
+		},
+		shouldPersistNormalizedFolder,
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -12,6 +12,17 @@ void test('hydrateLoadedSettings falls back to the default for malformed notesFo
 	assert.equal(result.shouldPersistNormalizedFolder, true);
 });
 
+void test('hydrateLoadedSettings repairs malformed root settings values', () => {
+	for (const malformedRoot of [null, [], 'bad']) {
+		const result = hydrateLoadedSettings(malformedRoot);
+
+		assert.deepEqual(result.settings, {
+			notesFolder: DEFAULT_SETTINGS.notesFolder,
+		});
+		assert.equal(result.shouldPersistNormalizedFolder, true);
+	}
+});
+
 void test('hydrateLoadedSettings preserves a trimmed notesFolder value and marks it for persistence', () => {
 	const result = hydrateLoadedSettings({ notesFolder: '  Football notes/matches  ' });
 

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { DEFAULT_SETTINGS, hydrateLoadedSettings } from './settings-data';
+
+void test('hydrateLoadedSettings falls back to the default for malformed notesFolder values', () => {
+	const result = hydrateLoadedSettings({ notesFolder: 123 });
+
+	assert.deepEqual(result.settings, {
+		notesFolder: DEFAULT_SETTINGS.notesFolder,
+	});
+	assert.equal(result.shouldPersistNormalizedFolder, true);
+});
+
+void test('hydrateLoadedSettings preserves a trimmed notesFolder value and marks it for persistence', () => {
+	const result = hydrateLoadedSettings({ notesFolder: '  Football notes/matches  ' });
+
+	assert.deepEqual(result.settings, {
+		notesFolder: 'Football notes/matches',
+	});
+	assert.equal(result.shouldPersistNormalizedFolder, true);
+});
+
+void test('hydrateLoadedSettings keeps the default notesFolder without forcing persistence when missing', () => {
+	const result = hydrateLoadedSettings({});
+
+	assert.deepEqual(result.settings, {
+		notesFolder: DEFAULT_SETTINGS.notesFolder,
+	});
+	assert.equal(result.shouldPersistNormalizedFolder, false);
+});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,14 +2,6 @@ import { App, PluginSettingTab, Setting } from 'obsidian';
 import type FootballNotesPlugin from './main';
 import { DEFAULT_MATCH_NOTES_FOLDER, normalizeMatchNotesFolder } from './types';
 
-export interface FootballNotesSettings {
-	notesFolder: string;
-}
-
-export const DEFAULT_SETTINGS: FootballNotesSettings = {
-	notesFolder: DEFAULT_MATCH_NOTES_FOLDER,
-};
-
 export class FootballNotesSettingTab extends PluginSettingTab {
 	plugin: FootballNotesPlugin;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { normalizePath } from 'obsidian';
+import { normalizeVaultPath } from './path-utils';
 
 export const DEFAULT_MATCH_NOTES_FOLDER = 'Football notes/matches';
 
@@ -18,7 +18,7 @@ export function normalizeMatchNotesFolder(folder: string): string {
 		return DEFAULT_MATCH_NOTES_FOLDER;
 	}
 
-	const normalizedFolder = normalizePath(trimmedFolder).replace(/^\/+/, '');
+	const normalizedFolder = normalizeVaultPath(trimmedFolder).replace(/^\/+/, '');
 
 	return normalizedFolder.length > 0 && normalizedFolder !== '.'
 		? normalizedFolder


### PR DESCRIPTION
This pull request introduces several improvements to the handling and normalization of vault paths and match note file creation, as well as a refactor of settings management. It also adds new and more comprehensive tests for these areas. The changes improve robustness when creating match note files, ensure consistent path normalization, and separate settings logic for better maintainability.

**Path normalization and settings refactor:**

* Introduced a new `normalizeVaultPath` utility in `src/path-utils.ts` and updated all folder and path normalization logic to use it instead of Obsidian's `normalizePath`, ensuring consistent handling of vault paths throughout the codebase. (`src/path-utils.ts`, `src/types.ts`, `src/services/match-note-paths.ts`) [[1]](diffhunk://#diff-1ff9102c69c02bb7a8951390768aaaf3270ae6b78d0cd19244b8385f6ad529daR1-R19) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL1-R1) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL21-R21) [[4]](diffhunk://#diff-ecac672263677c171631f2973cad593e2bf1663b6d264224cdcf990933524538L1-R2) [[5]](diffhunk://#diff-ecac672263677c171631f2973cad593e2bf1663b6d264224cdcf990933524538L47-R46)
* Refactored settings management by moving `FootballNotesSettings`, `DEFAULT_SETTINGS`, and related logic into a new `src/settings-data.ts` file. The new `hydrateLoadedSettings` function robustly normalizes and validates loaded settings, marking when normalization should be persisted. (`src/settings-data.ts`, `src/settings.ts`, `src/main.ts`) [[1]](diffhunk://#diff-8f15c70e49bc3265d1ee9d55ffa3d7a6a876e617f51eeb2a555dbf5f3e756eccR1-R39) [[2]](diffhunk://#diff-bb57a3bd912abc3ec2e729cb8a743838487677a5517683d0c8913a3619ac296aL5-L12) [[3]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL3-R4) [[4]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL16-R21)

**Match note file creation improvements:**

* Improved the match note file creation retry logic to limit the number of attempts to 100 and provide a clear error message if the limit is reached. Also made folder existence checks more robust and testable. (`src/services/match-note-files.ts`) [[1]](diffhunk://#diff-6f6d6948238575e6fd4e57b237fdf721c7a738ac2ca16e5383a882013ef88563L1-R8) [[2]](diffhunk://#diff-6f6d6948238575e6fd4e57b237fdf721c7a738ac2ca16e5383a882013ef88563L23-L29) [[3]](diffhunk://#diff-6f6d6948238575e6fd4e57b237fdf721c7a738ac2ca16e5383a882013ef88563L40-R54) [[4]](diffhunk://#diff-6f6d6948238575e6fd4e57b237fdf721c7a738ac2ca16e5383a882013ef88563L59-R67) [[5]](diffhunk://#diff-6f6d6948238575e6fd4e57b237fdf721c7a738ac2ca16e5383a882013ef88563L78-R86) [[6]](diffhunk://#diff-6f6d6948238575e6fd4e57b237fdf721c7a738ac2ca16e5383a882013ef88563R97-R106)

**Testing enhancements:**

* Added new tests for settings hydration and match note file creation, including edge cases for malformed settings and retry limits. (`src/settings.test.ts`, `src/services/match-note-files.test.ts`, `package.json`) [[1]](diffhunk://#diff-962ddaed72f2afde81e3068281cd9e75a50b045f7f60a43c3311f821e3a48809R1-R31) [[2]](diffhunk://#diff-cf0d3822125668e84fd8bc79e8cebc4ca90846c2f051bcae7f16bc1765749c58R1-R161) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L10-R10)

**Related Issues:**

* Resolve #30 
* Resolve #31 