### PR TITLE
test: add canonical match note template coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-		"test": "node --import jiti/register --test src/services/match-url-parser.test.ts src/commands/create-match-note-from-url.test.ts src/ui/match-url-modal-state.test.ts src/settings.test.ts src/services/match-note-files.test.ts",
+		"test": "node --import jiti/register --test src/services/match-url-parser.test.ts src/commands/create-match-note-from-url.test.ts src/ui/match-url-modal-state.test.ts src/settings.test.ts src/services/match-note-files.test.ts src/services/match-note-template.test.ts",
 		"prepare": "husky",
 		"format": "prettier . --write",
 		"format:check": "prettier . --check",

--- a/src/services/match-note-template.test.ts
+++ b/src/services/match-note-template.test.ts
@@ -43,3 +43,29 @@ void test('createMatchNoteDraft renders the canonical match note schema', () => 
 		'',
 	]);
 });
+
+void test('createMatchNoteDraft rejects an empty source URL', () => {
+	assert.throws(
+		() =>
+			createMatchNoteDraft({
+				source: {
+					sourceUrl: '   ',
+					sourceHost: 'example.com',
+				},
+				destinationFolder: 'Football notes/matches',
+			}),
+		/Match note source URL cannot be empty\./,
+	);
+});
+
+void test('createMatchNoteDraft normalizes the destination folder', () => {
+	const draft = createMatchNoteDraft({
+		source: {
+			sourceUrl: 'https://example.com/match',
+			sourceHost: 'example.com',
+		},
+		destinationFolder: '  Scratch/matches  ',
+	});
+
+	assert.equal(draft.folder, 'Scratch/matches');
+});

--- a/src/services/match-note-template.test.ts
+++ b/src/services/match-note-template.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createMatchNoteDraft } from './match-note-template';
+
+void test('createMatchNoteDraft renders the canonical match note schema', () => {
+	const draft = createMatchNoteDraft({
+		source: {
+			sourceUrl: 'https://example.com/match',
+			sourceHost: 'example.com',
+		},
+		destinationFolder: ' Football notes/matches ',
+	});
+
+	assert.equal(draft.title, 'New match note');
+	assert.equal(draft.folder, 'Football notes/matches');
+
+	const lines = draft.content.split('\n');
+
+	assert.deepEqual(lines.slice(0, 5), [
+		'---',
+		'type: match-note',
+		'sport: football',
+		'source_url: "https://example.com/match"',
+		'---',
+	]);
+
+	assert.deepEqual(lines.slice(5), [
+		'',
+		'# Match',
+		'',
+		'## Snapshot',
+		'',
+		'## Lineups',
+		'',
+		'## Match stats',
+		'',
+		'## Timeline',
+		'',
+		'## My observations',
+		'',
+		'## Tactical notes',
+		'',
+	]);
+});


### PR DESCRIPTION
This pull request adds a new test suite for the `createMatchNoteDraft` function to ensure it correctly generates match note drafts and handles edge cases. Additionally, it updates the test script in `package.json` to include this new test file.

**Testing improvements:**

* Added a new test file `src/services/match-note-template.test.ts` with tests for `createMatchNoteDraft`, covering correct rendering of the match note schema, rejection of empty source URLs, and normalization of the destination folder.
* Updated the `test` script in `package.json` to run the new `match-note-template.test.ts` file alongside existing tests.

**Related Issues:**

* Resolve #20 