### PR TITLE
refactor: split match note workflow from Obsidian command wiring

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-		"test": "node --import jiti/register --test src/services/match-url-parser.test.ts src/commands/create-match-note-from-url.test.ts src/ui/match-url-modal-state.test.ts src/settings.test.ts src/services/match-note-files.test.ts src/services/match-note-template.test.ts",
+		"test": "node --import jiti/register --test src/services/match-url-parser.test.ts src/commands/create-match-note-from-url.test.ts src/ui/match-url-modal-state.test.ts src/settings.test.ts src/services/match-note-files.test.ts src/services/match-note-template.test.ts src/services/match-note-workflow.test.ts",
 		"prepare": "husky",
 		"format": "prettier . --write",
 		"format:check": "prettier . --check",

--- a/src/commands/create-match-note-from-url.test.ts
+++ b/src/commands/create-match-note-from-url.test.ts
@@ -53,6 +53,63 @@ void test('registerCreateMatchNoteFromUrlCommand wires the command entrypoint', 
 	assert.equal(openCalls, 1);
 });
 
+void test('registerCreateMatchNoteFromUrlCommand submits the modal value through the workflow', async () => {
+	let capturedCommand: RegisteredCommand | undefined;
+	let capturedOnSubmit: ((value: string) => Promise<boolean>) | undefined;
+	const createdPaths: string[] = [];
+	const openedFiles: Array<{ name: string }> = [];
+	const notices: string[] = [];
+
+	const plugin = {
+		addCommand(command: RegisteredCommand) {
+			capturedCommand = command;
+			return command;
+		},
+		app: createTestApp(createdPaths, openedFiles),
+		settings: {
+			notesFolder: 'Scratch/matches',
+		},
+	} as unknown as FootballNotesPlugin;
+
+	registerCreateMatchNoteFromUrlCommand(plugin, {
+		createModal: (_app: unknown, onSubmit) => {
+			capturedOnSubmit = onSubmit;
+
+			return {
+				open() {
+					// The modal still opens as part of the command flow.
+				},
+			};
+		},
+		showNotice: (message) => {
+			notices.push(message);
+		},
+		logError: (message, error) => {
+			throw new Error(`${message}: ${(error as Error).message}`);
+		},
+	});
+
+	assert.ok(capturedCommand);
+
+	await capturedCommand?.callback();
+
+	assert.equal(typeof capturedOnSubmit, 'function');
+
+	const result = await capturedOnSubmit?.(' https://example.com/match ');
+
+	assert.equal(result, true);
+	assert.equal(createdPaths.length, 3);
+	assert.equal(createdPaths[0], 'Scratch');
+	assert.equal(createdPaths[1], 'Scratch/matches');
+	assert.match(
+		createdPaths[2] ?? '',
+		/^Scratch\/matches\/New match note \d{4}-\d{2}-\d{2} \d{2}-\d{2}-\d{2}\.md$/,
+	);
+	assert.equal(openedFiles.length, 1);
+	assert.equal(openedFiles[0]?.name.startsWith('New match note '), true);
+	assert.deepEqual(notices, [`Created match note: ${openedFiles[0]?.name}`]);
+});
+
 void test('registerCreateMatchNoteFromUrlCommand reports modal setup failures', async () => {
 	const calls: Array<unknown> = [];
 	let capturedCommand: RegisteredCommand | undefined;
@@ -87,3 +144,39 @@ void test('registerCreateMatchNoteFromUrlCommand reports modal setup failures', 
 		['notice', 'Could not open match note dialog. See console for details.'],
 	]);
 });
+
+function createTestApp(createdPaths: string[], openedFiles: Array<{ name: string }>) {
+	const entries = new Map<string, { children?: unknown[]; name: string }>();
+
+	return {
+		vault: {
+			getAbstractFileByPath(path: string) {
+				return entries.get(path) ?? null;
+			},
+			async createFolder(path: string) {
+				createdPaths.push(path);
+				entries.set(path, {
+					name: path.split('/').at(-1) ?? path,
+					children: [],
+				});
+			},
+			async create(path: string) {
+				createdPaths.push(path);
+				const file = {
+					name: path.split('/').at(-1) ?? path,
+				};
+				entries.set(path, file);
+				return file;
+			},
+		},
+		workspace: {
+			getLeaf() {
+				return {
+					async openFile(file: { name: string }) {
+						openedFiles.push(file);
+					},
+				};
+			},
+		},
+	};
+}

--- a/src/commands/create-match-note-from-url.test.ts
+++ b/src/commands/create-match-note-from-url.test.ts
@@ -1,14 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { type App, type TFile } from 'obsidian';
-
 import type FootballNotesPlugin from '../main';
-import { parseMatchUrl } from '../services/match-url-parser';
 import {
 	CREATE_MATCH_NOTE_FROM_URL_COMMAND_ID,
 	CREATE_MATCH_NOTE_FROM_URL_COMMAND_NAME,
-	createMatchNoteFromUrl,
 	registerCreateMatchNoteFromUrlCommand,
 } from './create-match-note-from-url';
 
@@ -17,117 +13,6 @@ interface RegisteredCommand {
 	name: string;
 	callback: () => Promise<void>;
 }
-
-void test('createMatchNoteFromUrl creates and opens a match note for a valid URL', async () => {
-	const calls: Array<unknown> = [];
-	const createdFile = createTestFile('New match note 2026-06-20 12-34-56.md');
-
-	const result = await createMatchNoteFromUrl(' HTTPS://EXAMPLE.COM/match ', {
-		destinationFolder: 'Football notes/matches',
-		createMatchNoteFile: async (input) => {
-			calls.push(['create', input]);
-			return createdFile;
-		},
-		openMatchNote: async (file) => {
-			calls.push(['open', file]);
-		},
-		showNotice: (message) => {
-			calls.push(['notice', message]);
-		},
-		logError: (message, error) => {
-			calls.push(['error', message, (error as Error).message]);
-		},
-	});
-
-	assert.equal(result, true);
-	assert.deepEqual(calls[0], [
-		'create',
-		{
-			source: {
-				sourceUrl: 'https://example.com/match',
-				sourceHost: 'example.com',
-			},
-			destinationFolder: 'Football notes/matches',
-		},
-	]);
-	assert.deepEqual(calls[1], ['open', createdFile]);
-	assert.deepEqual(calls[2], ['notice', `Created match note: ${createdFile.name}`]);
-	assert.equal(calls.length, 3);
-});
-
-void test('createMatchNoteFromUrl shows the parser error for invalid URLs', async () => {
-	const calls: Array<unknown> = [];
-
-	const result = await createMatchNoteFromUrl('ftp://example.com/match', {
-		destinationFolder: 'Football notes/matches',
-		createMatchNoteFile: async () => {
-			throw new Error('should not be called');
-		},
-		openMatchNote: async () => {
-			throw new Error('should not be called');
-		},
-		showNotice: (message) => {
-			calls.push(['notice', message]);
-		},
-		logError: (message, error) => {
-			calls.push(['error', message, (error as Error).message]);
-		},
-	});
-
-	assert.equal(result, false);
-	assert.deepEqual(calls, [['notice', 'Match URL must use http:// or https://.']]);
-});
-
-void test('createMatchNoteFromUrl reports creation failures', async () => {
-	const calls: Array<unknown> = [];
-
-	const result = await createMatchNoteFromUrl('https://example.com/match', {
-		destinationFolder: 'Football notes/matches',
-		createMatchNoteFile: async () => {
-			throw new Error('disk full');
-		},
-		openMatchNote: async () => {
-			throw new Error('should not be called');
-		},
-		showNotice: (message) => {
-			calls.push(['notice', message]);
-		},
-		logError: (message, error) => {
-			calls.push(['error', message, (error as Error).message]);
-		},
-	});
-
-	assert.equal(result, false);
-	assert.deepEqual(calls, [
-		['error', 'Failed to create match note from URL.', 'disk full'],
-		['notice', 'Could not create match note. See console for details.'],
-	]);
-});
-
-void test('createMatchNoteFromUrl reports open failures without hiding the created note', async () => {
-	const calls: Array<unknown> = [];
-	const createdFile = createTestFile('New match note 2026-06-20 12-34-56.md');
-
-	const result = await createMatchNoteFromUrl('https://example.com/match', {
-		destinationFolder: 'Football notes/matches',
-		createMatchNoteFile: async () => createdFile,
-		openMatchNote: async () => {
-			throw new Error('workspace unavailable');
-		},
-		showNotice: (message) => {
-			calls.push(['notice', message]);
-		},
-		logError: (message, error) => {
-			calls.push(['error', message, (error as Error).message]);
-		},
-	});
-
-	assert.equal(result, true);
-	assert.deepEqual(calls, [
-		['error', 'Created match note, but could not open it.', 'workspace unavailable'],
-		['notice', `Created match note: ${createdFile.name}, but could not open it automatically.`],
-	]);
-});
 
 void test('registerCreateMatchNoteFromUrlCommand wires the command entrypoint', async () => {
 	let capturedCommand: RegisteredCommand | undefined;
@@ -139,14 +24,14 @@ void test('registerCreateMatchNoteFromUrlCommand wires the command entrypoint', 
 			capturedCommand = command;
 			return command;
 		},
-		app: {} as App,
+		app: {} as never,
 		settings: {
 			notesFolder: 'Football notes/matches',
 		},
 	} as unknown as FootballNotesPlugin;
 
 	registerCreateMatchNoteFromUrlCommand(plugin, {
-		createModal: (_app, onSubmit) => {
+		createModal: (_app: unknown, onSubmit) => {
 			createModalCalls += 1;
 			assert.equal(typeof onSubmit, 'function');
 
@@ -177,7 +62,7 @@ void test('registerCreateMatchNoteFromUrlCommand reports modal setup failures', 
 			capturedCommand = command;
 			return command;
 		},
-		app: {} as App,
+		app: {} as never,
 		settings: {
 			notesFolder: 'Football notes/matches',
 		},
@@ -202,19 +87,3 @@ void test('registerCreateMatchNoteFromUrlCommand reports modal setup failures', 
 		['notice', 'Could not open match note dialog. See console for details.'],
 	]);
 });
-
-void test('parseMatchUrl keeps the workflow parser behavior intact', () => {
-	assert.equal(parseMatchUrl('https://example.com/match').ok, true);
-});
-
-function createTestFile(name: string): TFile {
-	return {
-		vault: undefined as never,
-		path: `Football notes/matches/${name}`,
-		name,
-		parent: null,
-		stat: undefined as never,
-		basename: name.replace(/\.md$/u, ''),
-		extension: 'md',
-	};
-}

--- a/src/commands/create-match-note-from-url.ts
+++ b/src/commands/create-match-note-from-url.ts
@@ -82,10 +82,6 @@ function defaultLogError(message: string, error: unknown): void {
 	console.error(message, error);
 }
 
-function isObsidianTFile(file: { name: string }): file is TFile {
-	return 'path' in file && 'basename' in file && 'vault' in file;
-}
-
 async function createDefaultMatchUrlModal(
 	app: App,
 	onSubmit: MatchUrlSubmitHandler,
@@ -104,16 +100,10 @@ export async function createMatchNoteFromUrl(
 	input: string,
 	dependencies: CreateMatchNoteFromUrlWorkflowDependencies,
 ): Promise<boolean> {
-	return await createMatchNoteFromUrlWorkflow(input, {
+	return await createMatchNoteFromUrlWorkflow<TFile>(input, {
 		destinationFolder: dependencies.destinationFolder,
 		createMatchNoteFile: dependencies.createMatchNoteFile,
-		openMatchNote: async (file) => {
-			if (!isObsidianTFile(file)) {
-				throw new Error('Created match note file is not an Obsidian TFile.');
-			}
-
-			await dependencies.openMatchNote(file);
-		},
+		openMatchNote: dependencies.openMatchNote,
 		showNotice: dependencies.showNotice,
 		logError: dependencies.logError,
 	});

--- a/src/commands/create-match-note-from-url.ts
+++ b/src/commands/create-match-note-from-url.ts
@@ -2,7 +2,7 @@ import type { App, TFile } from 'obsidian';
 
 import type FootballNotesPlugin from '../main';
 import { createMatchNoteFile } from '../services/match-note-files';
-import { parseMatchUrl, type MatchUrlParseResult } from '../services/match-url-parser';
+import { createMatchNoteFromUrlWorkflow } from '../services/match-note-workflow';
 import type { MatchNoteInput } from '../types';
 import type { MatchUrlSubmitHandler } from '../ui/match-url-modal';
 
@@ -11,7 +11,6 @@ export const CREATE_MATCH_NOTE_FROM_URL_COMMAND_NAME = 'Create match note from U
 
 export interface CreateMatchNoteFromUrlWorkflowDependencies {
 	destinationFolder: string;
-	parseMatchUrl?: (input: string) => MatchUrlParseResult;
 	createMatchNoteFile: (input: MatchNoteInput) => Promise<TFile>;
 	openMatchNote: (file: TFile) => Promise<void>;
 	showNotice: (message: string) => void;
@@ -83,6 +82,10 @@ function defaultLogError(message: string, error: unknown): void {
 	console.error(message, error);
 }
 
+function isObsidianTFile(file: { name: string }): file is TFile {
+	return 'path' in file && 'basename' in file && 'vault' in file;
+}
+
 async function createDefaultMatchUrlModal(
 	app: App,
 	onSubmit: MatchUrlSubmitHandler,
@@ -101,34 +104,17 @@ export async function createMatchNoteFromUrl(
 	input: string,
 	dependencies: CreateMatchNoteFromUrlWorkflowDependencies,
 ): Promise<boolean> {
-	const parseResult = (dependencies.parseMatchUrl ?? parseMatchUrl)(input);
+	return await createMatchNoteFromUrlWorkflow(input, {
+		destinationFolder: dependencies.destinationFolder,
+		createMatchNoteFile: dependencies.createMatchNoteFile,
+		openMatchNote: async (file) => {
+			if (!isObsidianTFile(file)) {
+				throw new Error('Created match note file is not an Obsidian TFile.');
+			}
 
-	if (!parseResult.ok) {
-		dependencies.showNotice(parseResult.error.message);
-		return false;
-	}
-
-	try {
-		const createdFile = await dependencies.createMatchNoteFile({
-			source: parseResult.value,
-			destinationFolder: dependencies.destinationFolder,
-		});
-
-		try {
-			await dependencies.openMatchNote(createdFile);
-		} catch (error) {
-			dependencies.logError('Created match note, but could not open it.', error);
-			dependencies.showNotice(
-				`Created match note: ${createdFile.name}, but could not open it automatically.`,
-			);
-			return true;
-		}
-
-		dependencies.showNotice(`Created match note: ${createdFile.name}`);
-		return true;
-	} catch (error) {
-		dependencies.logError('Failed to create match note from URL.', error);
-		dependencies.showNotice('Could not create match note. See console for details.');
-		return false;
-	}
+			await dependencies.openMatchNote(file);
+		},
+		showNotice: dependencies.showNotice,
+		logError: dependencies.logError,
+	});
 }

--- a/src/services/match-note-workflow.test.ts
+++ b/src/services/match-note-workflow.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createMatchNoteFromUrlWorkflow } from './match-note-workflow';
+
+void test('createMatchNoteFromUrlWorkflow creates and opens a match note for a valid URL', async () => {
+	const calls: Array<unknown> = [];
+	const createdFile = createTestFile('New match note 2026-06-20 12-34-56.md');
+
+	const result = await createMatchNoteFromUrlWorkflow(' HTTPS://EXAMPLE.COM/match ', {
+		destinationFolder: 'Football notes/matches',
+		createMatchNoteFile: async (input) => {
+			calls.push(['create', input]);
+			return createdFile;
+		},
+		openMatchNote: async (file) => {
+			calls.push(['open', file]);
+		},
+		showNotice: (message) => {
+			calls.push(['notice', message]);
+		},
+		logError: (message, error) => {
+			calls.push(['error', message, (error as Error).message]);
+		},
+	});
+
+	assert.equal(result, true);
+	assert.deepEqual(calls[0], [
+		'create',
+		{
+			source: {
+				sourceUrl: 'https://example.com/match',
+				sourceHost: 'example.com',
+			},
+			destinationFolder: 'Football notes/matches',
+		},
+	]);
+	assert.deepEqual(calls[1], ['open', createdFile]);
+	assert.deepEqual(calls[2], ['notice', `Created match note: ${createdFile.name}`]);
+	assert.equal(calls.length, 3);
+});
+
+void test('createMatchNoteFromUrlWorkflow shows the parser error for invalid URLs', async () => {
+	const calls: Array<unknown> = [];
+
+	const result = await createMatchNoteFromUrlWorkflow('ftp://example.com/match', {
+		destinationFolder: 'Football notes/matches',
+		createMatchNoteFile: async () => {
+			throw new Error('should not be called');
+		},
+		openMatchNote: async () => {
+			throw new Error('should not be called');
+		},
+		showNotice: (message) => {
+			calls.push(['notice', message]);
+		},
+		logError: (message, error) => {
+			calls.push(['error', message, (error as Error).message]);
+		},
+	});
+
+	assert.equal(result, false);
+	assert.deepEqual(calls, [['notice', 'Match URL must use http:// or https://.']]);
+});
+
+void test('createMatchNoteFromUrlWorkflow reports creation failures', async () => {
+	const calls: Array<unknown> = [];
+
+	const result = await createMatchNoteFromUrlWorkflow('https://example.com/match', {
+		destinationFolder: 'Football notes/matches',
+		createMatchNoteFile: async () => {
+			throw new Error('disk full');
+		},
+		openMatchNote: async () => {
+			throw new Error('should not be called');
+		},
+		showNotice: (message) => {
+			calls.push(['notice', message]);
+		},
+		logError: (message, error) => {
+			calls.push(['error', message, (error as Error).message]);
+		},
+	});
+
+	assert.equal(result, false);
+	assert.deepEqual(calls, [
+		['error', 'Failed to create match note from URL.', 'disk full'],
+		['notice', 'Could not create match note. See console for details.'],
+	]);
+});
+
+void test('createMatchNoteFromUrlWorkflow reports open failures without hiding the created note', async () => {
+	const calls: Array<unknown> = [];
+	const createdFile = createTestFile('New match note 2026-06-20 12-34-56.md');
+
+	const result = await createMatchNoteFromUrlWorkflow('https://example.com/match', {
+		destinationFolder: 'Football notes/matches',
+		createMatchNoteFile: async () => createdFile,
+		openMatchNote: async () => {
+			throw new Error('workspace unavailable');
+		},
+		showNotice: (message) => {
+			calls.push(['notice', message]);
+		},
+		logError: (message, error) => {
+			calls.push(['error', message, (error as Error).message]);
+		},
+	});
+
+	assert.equal(result, true);
+	assert.deepEqual(calls, [
+		['error', 'Created match note, but could not open it.', 'workspace unavailable'],
+		['notice', `Created match note: ${createdFile.name}, but could not open it automatically.`],
+	]);
+});
+
+function createTestFile(name: string): { name: string } {
+	return { name };
+}

--- a/src/services/match-note-workflow.ts
+++ b/src/services/match-note-workflow.ts
@@ -5,19 +5,20 @@ export interface MatchNoteCreatedFile {
 	name: string;
 }
 
-export interface MatchNoteWorkflowDependencies {
+export interface MatchNoteWorkflowDependencies<
+	TCreatedFile extends MatchNoteCreatedFile = MatchNoteCreatedFile,
+> {
 	destinationFolder: string;
 	parseMatchUrl?: (input: string) => MatchUrlParseResult;
-	createMatchNoteFile: (input: MatchNoteInput) => Promise<MatchNoteCreatedFile>;
-	openMatchNote: (file: MatchNoteCreatedFile) => Promise<void>;
+	createMatchNoteFile: (input: MatchNoteInput) => Promise<TCreatedFile>;
+	openMatchNote: (file: TCreatedFile) => Promise<void>;
 	showNotice: (message: string) => void;
 	logError: (message: string, error: unknown) => void;
 }
 
-export async function createMatchNoteFromUrlWorkflow(
-	input: string,
-	dependencies: MatchNoteWorkflowDependencies,
-): Promise<boolean> {
+export async function createMatchNoteFromUrlWorkflow<
+	TCreatedFile extends MatchNoteCreatedFile = MatchNoteCreatedFile,
+>(input: string, dependencies: MatchNoteWorkflowDependencies<TCreatedFile>): Promise<boolean> {
 	const parseResult = (dependencies.parseMatchUrl ?? parseMatchUrl)(input);
 
 	if (!parseResult.ok) {

--- a/src/services/match-note-workflow.ts
+++ b/src/services/match-note-workflow.ts
@@ -1,0 +1,51 @@
+import { parseMatchUrl, type MatchUrlParseResult } from './match-url-parser';
+import type { MatchNoteInput } from '../types';
+
+export interface MatchNoteCreatedFile {
+	name: string;
+}
+
+export interface MatchNoteWorkflowDependencies {
+	destinationFolder: string;
+	parseMatchUrl?: (input: string) => MatchUrlParseResult;
+	createMatchNoteFile: (input: MatchNoteInput) => Promise<MatchNoteCreatedFile>;
+	openMatchNote: (file: MatchNoteCreatedFile) => Promise<void>;
+	showNotice: (message: string) => void;
+	logError: (message: string, error: unknown) => void;
+}
+
+export async function createMatchNoteFromUrlWorkflow(
+	input: string,
+	dependencies: MatchNoteWorkflowDependencies,
+): Promise<boolean> {
+	const parseResult = (dependencies.parseMatchUrl ?? parseMatchUrl)(input);
+
+	if (!parseResult.ok) {
+		dependencies.showNotice(parseResult.error.message);
+		return false;
+	}
+
+	try {
+		const createdFile = await dependencies.createMatchNoteFile({
+			source: parseResult.value,
+			destinationFolder: dependencies.destinationFolder,
+		});
+
+		try {
+			await dependencies.openMatchNote(createdFile);
+		} catch (error) {
+			dependencies.logError('Created match note, but could not open it.', error);
+			dependencies.showNotice(
+				`Created match note: ${createdFile.name}, but could not open it automatically.`,
+			);
+			return true;
+		}
+
+		dependencies.showNotice(`Created match note: ${createdFile.name}`);
+		return true;
+	} catch (error) {
+		dependencies.logError('Failed to create match note from URL.', error);
+		dependencies.showNotice('Could not create match note. See console for details.');
+		return false;
+	}
+}


### PR DESCRIPTION
This pull request refactors the workflow for creating match notes from URLs to improve modularity and testability. The main logic for parsing the URL, creating the note, and handling errors has been extracted into a new workflow module, and its tests have been moved and expanded. The command code now delegates to this workflow, resulting in cleaner and more maintainable code.

**Refactoring and modularization:**

* Extracted the core logic for creating a match note from a URL into a new workflow function `createMatchNoteFromUrlWorkflow` in `src/services/match-note-workflow.ts`, making it reusable and easier to test.
* Updated `createMatchNoteFromUrl` in `src/commands/create-match-note-from-url.ts` to delegate its logic to the new workflow function, simplifying the command implementation. [[1]](diffhunk://#diff-fde772dd2245818ffa3e3760748aeae40926c7d49dc8151a842c7d685a50a32cL5-R5) [[2]](diffhunk://#diff-fde772dd2245818ffa3e3760748aeae40926c7d49dc8151a842c7d685a50a32cL104-L133)

**Testing improvements:**

* Moved and expanded tests for the match note creation workflow into a new test file `src/services/match-note-workflow.test.ts`, ensuring comprehensive coverage of the new workflow module.
* Updated the test script in `package.json` to include the new workflow test file.
* Removed now-redundant workflow-related tests and helper functions from `src/commands/create-match-note-from-url.test.ts`, as these are now covered in the new workflow test file. [[1]](diffhunk://#diff-efdb49f30680992431728e73450601a973b9bf97d7d65a2b01076596dac2675eL21-L131) [[2]](diffhunk://#diff-efdb49f30680992431728e73450601a973b9bf97d7d65a2b01076596dac2675eL205-L220)

**Minor test cleanup:**

* Adjusted type assertions and parameters in remaining tests for clarity and correctness. [[1]](diffhunk://#diff-efdb49f30680992431728e73450601a973b9bf97d7d65a2b01076596dac2675eL142-R34) [[2]](diffhunk://#diff-efdb49f30680992431728e73450601a973b9bf97d7d65a2b01076596dac2675eL180-R65)

**Related Issues:**

* Resolve #29 