### PR TITLE
chore: move obsidian to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
 			"name": "football-notes",
 			"version": "0.1.1",
 			"license": "0-BSD",
-			"dependencies": {
-				"obsidian": "latest"
-			},
 			"devDependencies": {
 				"@eslint/js": "9.30.1",
 				"@types/node": "^20.17.0",
@@ -20,6 +17,7 @@
 				"husky": "^9.1.7",
 				"jiti": "2.6.1",
 				"lint-staged": "^16.4.0",
+				"obsidian": "^1.10.3",
 				"prettier": "^3.8.1",
 				"tslib": "2.4.0",
 				"typescript": "^5.8.3",
@@ -33,6 +31,7 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
 			"integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
+			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -43,6 +42,7 @@
 			"version": "6.38.6",
 			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
 			"integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
+			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -705,6 +705,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -808,6 +809,7 @@
 			"version": "5.60.8",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
 			"integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/tern": "*"
@@ -828,6 +830,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
@@ -865,6 +868,7 @@
 			"version": "0.23.9",
 			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
 			"integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "*"
@@ -1607,6 +1611,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
 			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -4064,6 +4069,7 @@
 			"version": "2.29.4",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
 			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -4210,6 +4216,7 @@
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.10.3.tgz",
 			"integrity": "sha512-VP+ZSxNMG7y6Z+sU9WqLvJAskCfkFrTz2kFHWmmzis+C+4+ELjk/sazwcTHrHXNZlgCeo8YOlM6SOrAFCynNew==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/codemirror": "5.60.8",
@@ -5086,6 +5093,7 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
 			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},
@@ -5419,6 +5427,7 @@
 			"version": "2.2.8",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+			"dev": true,
 			"license": "MIT",
 			"peer": true
 		},

--- a/package.json
+++ b/package.json
@@ -40,11 +40,9 @@
 		"jiti": "2.6.1",
 		"lint-staged": "^16.4.0",
 		"prettier": "^3.8.1",
+		"obsidian": "^1.10.3",
 		"tslib": "2.4.0",
 		"typescript": "^5.8.3",
 		"typescript-eslint": "8.35.1"
-	},
-	"dependencies": {
-		"obsidian": "latest"
 	}
 }


### PR DESCRIPTION
## Summary
Move `obsidian` from `dependencies` to `devDependencies` and pin it to an intentional caret range (`^1.10.3`), matching the version already resolved in `package-lock.json`.

This is a packaging-only change. `obsidian` remains externalized in the esbuild config, so runtime behavior is unchanged.

## Verification
* `npm test`
* `npm run build`
* `npm run lint`
* `git diff --check`

## Related issue
* Resolve #32