### PR TITLE
chore: enforce format check in CI and remove scaffold leftovers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
                   cache: 'npm'
             - run: npm ci
+            - run: npm run format:check
             - run: npm run version:check
             - run: npm run test
             - run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## [0.1.1](https://github.com/FerdiHS/obsidian-football-notes/compare/football-notes-0.1.0...football-notes-0.1.1) (2026-03-26)
 
-
 ### Bug Fixes
 
-* rename plugin id to football-notes ([#12](https://github.com/FerdiHS/obsidian-football-notes/issues/12)) ([a8d8667](https://github.com/FerdiHS/obsidian-football-notes/commit/a8d8667e48eec6a8f27fa81d16342bd8e48c042e))
+- rename plugin id to football-notes ([#12](https://github.com/FerdiHS/obsidian-football-notes/issues/12)) ([a8d8667](https://github.com/FerdiHS/obsidian-football-notes/commit/a8d8667e48eec6a8f27fa81d16342bd8e48c042e))
 
 ## Changelog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ The canonical local setup is to clone this repository directly into the plugin f
 <Vault>/.obsidian/plugins/football-notes
 ```
 
-That keeps the generated `main.js`, `manifest.json`, and `styles.css` at the plugin root where Obsidian expects them.
+That keeps the generated `main.js` and `manifest.json` at the plugin root where Obsidian expects them. `styles.css` is optional and only needed if the plugin later ships CSS.
 
 ## Local workflow
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Football Notes is an Obsidian community plugin for creating structured football 
 
 ## Status
 
-This repository is in an early MVP state. The immediate goal is to replace the sample-plugin scaffold with a clean foundation for real feature work.
+This repository is in an early MVP state focused on structured match-note generation and a stable contributor workflow.
 
 Planned focus areas:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Football Notes is an Obsidian community plugin for creating structured football 
 
 ## Status
 
-This repository is currently in the bootstrap phase. The immediate goal is to replace the sample-plugin scaffold with a clean foundation for real feature work.
+This repository is in an early MVP state. The immediate goal is to replace the sample-plugin scaffold with a clean foundation for real feature work.
 
 Planned focus areas:
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Install the plugin into:
 <Vault>/.obsidian/plugins/football-notes/
 ```
 
-and place `main.js`, `manifest.json`, and `styles.css` there.
+and place `main.js` and `manifest.json` there. Add `styles.css` only if the plugin later ships CSS.
 
 For the recommended direct-checkout workflow and local hook setup, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,0 @@
-/*
-
-This CSS file will be included with your plugin, and
-available in the app when your plugin is enabled.
-
-If your plugin does not need CSS, delete this file.
-
-*/


### PR DESCRIPTION
This pull request includes several improvements to documentation and CI workflow for the `football-notes` plugin. The main changes clarify the usage of the `styles.css` file, making it optional unless custom CSS is needed, and add a formatting check to the CI process.

**Documentation updates:**

* Updated `README.md` and `CONTRIBUTING.md` to clarify that `styles.css` is optional and should only be included if the plugin ships custom CSS. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R58) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L15-R15)
* Removed the unused `styles.css` file from the repository.

**CI/CD improvements:**

* Added a `format:check` step to the GitHub Actions workflow to ensure code formatting is validated during CI.

**Changelog formatting:**

* Minor formatting fix in `CHANGELOG.md` for consistency.

**Related Issues:**

* Resolve #33 
* Resolve #34 