### PR TITLE
fix: reject manual match inputs with colliding team-note paths

### DIFF
--- a/src/services/manual-match-note-input.test.ts
+++ b/src/services/manual-match-note-input.test.ts
@@ -5,6 +5,7 @@ import {
 	normalizeManualMatchDate,
 	normalizeManualMatchNoteWikiLinkTarget,
 	normalizeRequiredManualMatchNoteField,
+	validateManualMatchNoteTeamPathCollision,
 } from './manual-match-note-input';
 
 void test('normalizeManualMatchDate accepts trimmed ISO dates', () => {
@@ -72,4 +73,27 @@ void test('normalizeRequiredManualMatchNoteField trims and rejects empty fields'
 		result.ok ? undefined : result.error.message,
 		'Manual match note away team cannot be empty.',
 	);
+});
+
+void test('validateManualMatchNoteTeamPathCollision rejects exact, whitespace-equivalent, and sanitized collisions', () => {
+	for (const [homeTeam, awayTeam] of [
+		['Real Madrid', 'Real Madrid'],
+		['  Real Madrid  ', 'Real Madrid'],
+		['A:B', 'A-B'],
+	] as const) {
+		const result = validateManualMatchNoteTeamPathCollision(homeTeam, awayTeam);
+
+		assert.equal(result.ok, false);
+		assert.equal(
+			result.ok ? undefined : result.error.message,
+			'Manual match note home and away teams must be different.',
+		);
+	}
+});
+
+void test('validateManualMatchNoteTeamPathCollision allows distinct team paths', () => {
+	assert.deepEqual(validateManualMatchNoteTeamPathCollision('Real Madrid', 'Barcelona'), {
+		ok: true,
+		value: undefined,
+	});
 });

--- a/src/services/manual-match-note-input.test.ts
+++ b/src/services/manual-match-note-input.test.ts
@@ -78,6 +78,7 @@ void test('normalizeRequiredManualMatchNoteField trims and rejects empty fields'
 void test('validateManualMatchNoteTeamPathCollision rejects exact, whitespace-equivalent, and sanitized collisions', () => {
 	for (const [homeTeam, awayTeam] of [
 		['Real Madrid', 'Real Madrid'],
+		['Real Madrid', 'real madrid'],
 		['  Real Madrid  ', 'Real Madrid'],
 		['A:B', 'A-B'],
 	] as const) {

--- a/src/services/manual-match-note-input.ts
+++ b/src/services/manual-match-note-input.ts
@@ -1,3 +1,5 @@
+import { sanitizeNoteTitle } from './note-title';
+
 export interface ManualMatchNoteValidationSuccess<T> {
 	ok: true;
 	value: T;
@@ -116,4 +118,23 @@ export function normalizeOptionalManualMatchNoteSourceUrl(
 	const trimmedValue = value?.trim();
 
 	return trimmedValue !== undefined && trimmedValue.length > 0 ? trimmedValue : undefined;
+}
+
+export function validateManualMatchNoteTeamPathCollision(
+	homeTeam: string,
+	awayTeam: string,
+): ManualMatchNoteValidationResult<void> {
+	if (sanitizeNoteTitle(homeTeam) === sanitizeNoteTitle(awayTeam)) {
+		return {
+			ok: false,
+			error: {
+				message: 'Manual match note home and away teams must be different.',
+			},
+		};
+	}
+
+	return {
+		ok: true,
+		value: undefined,
+	};
 }

--- a/src/services/manual-match-note-input.ts
+++ b/src/services/manual-match-note-input.ts
@@ -124,7 +124,10 @@ export function validateManualMatchNoteTeamPathCollision(
 	homeTeam: string,
 	awayTeam: string,
 ): ManualMatchNoteValidationResult<void> {
-	if (sanitizeNoteTitle(homeTeam) === sanitizeNoteTitle(awayTeam)) {
+	const normalizedHomeTeam = sanitizeNoteTitle(homeTeam).toLowerCase();
+	const normalizedAwayTeam = sanitizeNoteTitle(awayTeam).toLowerCase();
+
+	if (normalizedHomeTeam === normalizedAwayTeam) {
 		return {
 			ok: false,
 			error: {

--- a/src/services/manual-match-note.test.ts
+++ b/src/services/manual-match-note.test.ts
@@ -245,6 +245,52 @@ void test('createManualMatchNoteWorkflow rejects match teams that normalize to e
 	]);
 });
 
+void test('createManualMatchNoteWorkflow rejects colliding team paths before any downstream work', async () => {
+	for (const [homeTeam, awayTeam] of [
+		['Real Madrid', 'Real Madrid'],
+		['  Real Madrid  ', 'Real Madrid'],
+		['A:B', 'A-B'],
+	] as const) {
+		const calls: Array<unknown> = [];
+
+		const result = await createManualMatchNoteWorkflow(
+			{
+				homeTeam,
+				awayTeam,
+				matchDate: '2026-07-01',
+				competition: 'La Liga',
+				sourceUrl: 'https://example.com/match',
+			},
+			{
+				destinationFolder: 'Football notes/matches',
+				parseMatchUrl: () => {
+					throw new Error('should not be called');
+				},
+				resolveTeamNotes: async () => {
+					throw new Error('should not be called');
+				},
+				createMatchNoteFile: async () => {
+					throw new Error('should not be called');
+				},
+				openMatchNote: async () => {
+					throw new Error('should not be called');
+				},
+				showNotice: (message) => {
+					calls.push(['notice', message]);
+				},
+				logError: (message, error) => {
+					calls.push(['error', message, (error as Error).message]);
+				},
+			},
+		);
+
+		assert.equal(result, false);
+		assert.deepEqual(calls, [
+			['notice', 'Manual match note home and away teams must be different.'],
+		]);
+	}
+});
+
 void test('createManualMatchNoteWorkflow reports team note resolution failures', async () => {
 	const calls: Array<unknown> = [];
 

--- a/src/services/manual-match-note.test.ts
+++ b/src/services/manual-match-note.test.ts
@@ -248,6 +248,7 @@ void test('createManualMatchNoteWorkflow rejects match teams that normalize to e
 void test('createManualMatchNoteWorkflow rejects colliding team paths before any downstream work', async () => {
 	for (const [homeTeam, awayTeam] of [
 		['Real Madrid', 'Real Madrid'],
+		['Real Madrid', 'real madrid'],
 		['  Real Madrid  ', 'Real Madrid'],
 		['A:B', 'A-B'],
 	] as const) {

--- a/src/services/manual-match-note.test.ts
+++ b/src/services/manual-match-note.test.ts
@@ -245,6 +245,46 @@ void test('createManualMatchNoteWorkflow rejects match teams that normalize to e
 	]);
 });
 
+void test('createManualMatchNoteWorkflow reports empty home teams before treating them as a collision', async () => {
+	const calls: Array<unknown> = [];
+
+	const result = await createManualMatchNoteWorkflow(
+		{
+			homeTeam: '.',
+			awayTeam: '...',
+			matchDate: '2026-07-01',
+			competition: 'La Liga',
+			sourceUrl: 'https://example.com/match',
+		},
+		{
+			destinationFolder: 'Football notes/matches',
+			parseMatchUrl: () => {
+				throw new Error('should not be called');
+			},
+			resolveTeamNotes: async () => {
+				throw new Error('should not be called');
+			},
+			createMatchNoteFile: async () => {
+				throw new Error('should not be called');
+			},
+			openMatchNote: async () => {
+				throw new Error('should not be called');
+			},
+			showNotice: (message) => {
+				calls.push(['notice', message]);
+			},
+			logError: (message, error) => {
+				calls.push(['error', message, (error as Error).message]);
+			},
+		},
+	);
+
+	assert.equal(result, false);
+	assert.deepEqual(calls, [
+		['notice', 'Manual match note home team cannot become a valid wiki link target.'],
+	]);
+});
+
 void test('createManualMatchNoteWorkflow rejects colliding team paths before any downstream work', async () => {
 	for (const [homeTeam, awayTeam] of [
 		['Real Madrid', 'Real Madrid'],

--- a/src/services/manual-match-note.ts
+++ b/src/services/manual-match-note.ts
@@ -6,6 +6,7 @@ import {
 	normalizeRequiredManualMatchNoteField,
 	normalizeManualMatchNoteWikiLinkTarget,
 	normalizeOptionalManualMatchNoteSourceUrl,
+	validateManualMatchNoteTeamPathCollision,
 } from './manual-match-note-input';
 import { formatUserFacingErrorNotice } from './user-facing-error';
 import type { ManualMatchNoteInput, ManualMatchNoteSubmission } from '../types';
@@ -155,6 +156,11 @@ function normalizeManualMatchNoteSubmission(
 	const competition = normalizeRequiredManualMatchNoteField(input.competition, 'competition');
 	if (!competition.ok) {
 		return competition;
+	}
+
+	const teamCollision = validateManualMatchNoteTeamPathCollision(homeTeam.value, awayTeam.value);
+	if (!teamCollision.ok) {
+		return teamCollision;
 	}
 
 	const homeTeamLinkTarget = normalizeManualMatchNoteWikiLinkTarget(homeTeam.value, 'home team');

--- a/src/services/manual-match-note.ts
+++ b/src/services/manual-match-note.ts
@@ -158,11 +158,6 @@ function normalizeManualMatchNoteSubmission(
 		return competition;
 	}
 
-	const teamCollision = validateManualMatchNoteTeamPathCollision(homeTeam.value, awayTeam.value);
-	if (!teamCollision.ok) {
-		return teamCollision;
-	}
-
 	const homeTeamLinkTarget = normalizeManualMatchNoteWikiLinkTarget(homeTeam.value, 'home team');
 	if (!homeTeamLinkTarget.ok) {
 		return homeTeamLinkTarget;
@@ -171,6 +166,11 @@ function normalizeManualMatchNoteSubmission(
 	const awayTeamLinkTarget = normalizeManualMatchNoteWikiLinkTarget(awayTeam.value, 'away team');
 	if (!awayTeamLinkTarget.ok) {
 		return awayTeamLinkTarget;
+	}
+
+	const teamCollision = validateManualMatchNoteTeamPathCollision(homeTeam.value, awayTeam.value);
+	if (!teamCollision.ok) {
+		return teamCollision;
 	}
 
 	const sourceUrl = normalizeOptionalManualMatchNoteSourceUrl(input.sourceUrl);


### PR DESCRIPTION
This pull request introduces validation to prevent manual match notes from being created when the home and away teams would result in colliding or indistinguishable note paths, even after normalization and sanitization. This ensures data integrity by avoiding duplicate or conflicting match notes. The main changes include the implementation of the collision check, integration of this check into the workflow, and comprehensive tests to verify the new behavior.

### Validation and Workflow Updates

* Added `validateManualMatchNoteTeamPathCollision` to `manual-match-note-input.ts`, which normalizes and sanitizes team names to detect and reject collisions such as identical, case-insensitive, whitespace-trimmed, or sanitized-equivalent names (e.g., `'A:B'` vs `'A-B'`). [[1]](diffhunk://#diff-011d0a6def8652fa30660812963fb4ede949e3c957ec66a76711c775a17bc955R1-R2) [[2]](diffhunk://#diff-011d0a6def8652fa30660812963fb4ede949e3c957ec66a76711c775a17bc955R122-R143)
* Integrated the new collision check into the manual match note creation workflow by invoking it in `normalizeManualMatchNoteSubmission` and returning an error if a collision is detected.
* Updated imports in relevant files to include the new validation function. [[1]](diffhunk://#diff-47e9d9b3258836b8d561a0eb378504fb1d05f167bd94709685eab435581a2efeR8) [[2]](diffhunk://#diff-9a33c585f92c886b01d72c647a187a3586e5acf28a7fa5ab129a680327d11181R9)

### Testing

* Added unit tests for `validateManualMatchNoteTeamPathCollision`, covering both rejection of colliding team names and acceptance of distinct team names.
* Added integration tests to ensure that the workflow rejects colliding team paths before any downstream processing occurs, and that the correct user-facing notice is shown.

**Related Issues:**

* Resolve #63 