### PR TITLE
test: auto-discover test files in npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-		"test": "node --import jiti/register --test .github/workflows/release-please-auto-merge.test.mjs .github/workflows/release-please-version-sync.test.mjs version-bump.test.mjs src/services/match-url-parser.test.ts src/commands/create-match-note-from-url.test.ts src/commands/create-match-note-manually.test.ts src/commands/create-team-note.test.ts src/commands/create-player-note.test.ts src/commands/register-named-note-command.test.ts src/ui/match-url-modal-state.test.ts src/ui/named-note-modal.test.ts src/settings.test.ts src/team-player-note-schemas.test.ts src/services/match-note-files.test.ts src/services/team-player-note-files.test.ts src/services/match-note-template.test.ts src/services/team-player-note-template.test.ts src/services/note-title.test.ts src/services/match-note-workflow.test.ts src/services/team-player-note-workflow.test.ts src/services/manual-match-note-input.test.ts src/services/manual-match-note.test.ts src/services/manual-match-team-notes.test.ts src/services/user-facing-error.test.ts",
+		"test": "node test-runner.mjs",
 		"check": "npm run test && npm run build && npm run lint && npm run format:check",
 		"prepare": "husky",
 		"format": "prettier . --write",

--- a/test-runner.mjs
+++ b/test-runner.mjs
@@ -1,7 +1,6 @@
 import { spawnSync } from 'node:child_process';
-import { createRequire } from 'node:module';
 import { readdirSync } from 'node:fs';
-import { dirname, relative, resolve, sep } from 'node:path';
+import { relative, resolve, sep } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
@@ -42,44 +41,32 @@ export function collectTestFiles(rootDir) {
 	return discoveredFiles.sort();
 }
 
-function run() {
-	const require = createRequire(import.meta.url);
-	const rootDir = process.cwd();
-	const jitiRegisterPath = resolve(
-		dirname(require.resolve('jiti/package.json')),
-		'lib/jiti-register.mjs',
-	);
+export function run({ proc = process, spawn = spawnSync } = {}) {
+	const rootDir = proc.cwd();
 	const testFiles = collectTestFiles(rootDir).map((file) => resolve(rootDir, file));
-	const childEnv = { ...process.env };
+
+	if (testFiles.length === 0) {
+		proc.stderr.write('No test files found.\n');
+		proc.exit(1);
+	}
+
+	const childEnv = { ...proc.env };
 	delete childEnv.NODE_TEST_CONTEXT;
-	const result = spawnSync(
-		process.execPath,
-		['--import', jitiRegisterPath, '--test', ...testFiles],
+
+	const result = spawn(
+		proc.execPath,
+		['--import', 'jiti/register', '--test', ...testFiles],
 		{
-			encoding: 'utf8',
 			env: childEnv,
+			stdio: 'inherit',
 		},
 	);
 
 	if (result.error) {
-		process.exit(1);
+		proc.exit(1);
 	}
 
-	if (result.status === 0) {
-		if (result.stdout) {
-			process.stdout.write(result.stdout);
-		}
-	} else {
-		if (result.stdout) {
-			process.stderr.write(result.stdout);
-		}
-	}
-
-	if (result.stderr) {
-		process.stderr.write(result.stderr);
-	}
-
-	process.exit(result.status ?? 1);
+	proc.exit(result.status ?? 1);
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/test-runner.mjs
+++ b/test-runner.mjs
@@ -1,0 +1,87 @@
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { readdirSync } from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const SUPPORTED_TEST_SUFFIXES = ['.test.ts', '.test.mjs'];
+
+function toPosixPath(path) {
+	return path.split(sep).join('/');
+}
+
+export function collectTestFiles(rootDir) {
+	const discoveredFiles = [];
+
+	function walk(currentDir) {
+		for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
+			if (entry.isDirectory()) {
+				if (entry.name === 'node_modules') {
+					continue;
+				}
+
+				walk(resolve(currentDir, entry.name));
+				continue;
+			}
+
+			if (!entry.isFile()) {
+				continue;
+			}
+
+			if (!SUPPORTED_TEST_SUFFIXES.some((suffix) => entry.name.endsWith(suffix))) {
+				continue;
+			}
+
+			discoveredFiles.push(toPosixPath(relative(rootDir, resolve(currentDir, entry.name))));
+		}
+	}
+
+	walk(rootDir);
+
+	return discoveredFiles.sort();
+}
+
+function run() {
+	const require = createRequire(import.meta.url);
+	const rootDir = process.cwd();
+	const jitiRegisterPath = resolve(
+		dirname(require.resolve('jiti/package.json')),
+		'lib/jiti-register.mjs',
+	);
+	const testFiles = collectTestFiles(rootDir).map((file) => resolve(rootDir, file));
+	const childEnv = { ...process.env };
+	delete childEnv.NODE_TEST_CONTEXT;
+	const result = spawnSync(
+		process.execPath,
+		['--import', jitiRegisterPath, '--test', ...testFiles],
+		{
+			encoding: 'utf8',
+			env: childEnv,
+		},
+	);
+
+	if (result.error) {
+		process.exit(1);
+	}
+
+	if (result.status === 0) {
+		if (result.stdout) {
+			process.stdout.write(result.stdout);
+		}
+	} else {
+		if (result.stdout) {
+			process.stderr.write(result.stdout);
+		}
+	}
+
+	if (result.stderr) {
+		process.stderr.write(result.stderr);
+	}
+
+	process.exit(result.status ?? 1);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	run();
+}

--- a/test-runner.mjs
+++ b/test-runner.mjs
@@ -53,14 +53,10 @@ export function run({ proc = process, spawn = spawnSync } = {}) {
 	const childEnv = { ...proc.env };
 	delete childEnv.NODE_TEST_CONTEXT;
 
-	const result = spawn(
-		proc.execPath,
-		['--import', 'jiti/register', '--test', ...testFiles],
-		{
-			env: childEnv,
-			stdio: 'inherit',
-		},
-	);
+	const result = spawn(proc.execPath, ['--import', 'jiti/register', '--test', ...testFiles], {
+		env: childEnv,
+		stdio: 'inherit',
+	});
 
 	if (result.error) {
 		proc.exit(1);

--- a/test-runner.mjs
+++ b/test-runner.mjs
@@ -16,7 +16,7 @@ export function collectTestFiles(rootDir) {
 	function walk(currentDir) {
 		for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
 			if (entry.isDirectory()) {
-				if (entry.name === 'node_modules') {
+				if (entry.name === 'node_modules' || entry.name === '.git') {
 					continue;
 				}
 

--- a/test-runner.test.mjs
+++ b/test-runner.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import process from 'node:process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { collectTestFiles } from './test-runner.mjs';
+
+const launcherPath = fileURLToPath(new URL('./test-runner.mjs', import.meta.url));
+
+function writeFixture(root, relativePath, contents) {
+	const fullPath = join(root, relativePath);
+	mkdirSync(dirname(fullPath), { recursive: true });
+	writeFileSync(fullPath, contents);
+}
+
+test('collectTestFiles returns sorted repo-relative supported tests', () => {
+	const root = mkdtempSync(join(tmpdir(), 'football-notes-test-runner-'));
+	try {
+		writeFixture(
+			root,
+			'.github/workflows/b.test.mjs',
+			"import test from 'node:test'; test('b', () => {});",
+		);
+		writeFixture(root, 'src/b.test.ts', "import test from 'node:test'; test('b', () => {});");
+		writeFixture(root, 'src/a.test.ts', "import test from 'node:test'; test('a', () => {});");
+		writeFixture(root, 'src/ui/named-note-modal-test-support.ts', 'export {};');
+		writeFixture(
+			root,
+			'node_modules/ignored.test.ts',
+			"import test from 'node:test'; test('ignored', () => {});",
+		);
+
+		assert.deepEqual(collectTestFiles(root), [
+			'.github/workflows/b.test.mjs',
+			'src/a.test.ts',
+			'src/b.test.ts',
+		]);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test('launcher returns non-zero when a discovered test fails', () => {
+	const root = mkdtempSync(join(tmpdir(), 'football-notes-test-runner-'));
+	try {
+		writeFixture(root, 'pass.test.ts', "import test from 'node:test'; test('pass', () => {});");
+		writeFixture(
+			root,
+			'fail.test.ts',
+			"import assert from 'node:assert/strict'; import test from 'node:test'; test('fail', () => assert.fail('boom'));",
+		);
+
+		const result = spawnSync(process.execPath, [launcherPath], {
+			cwd: root,
+			encoding: 'utf8',
+		});
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /boom/);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/test-runner.test.mjs
+++ b/test-runner.test.mjs
@@ -25,6 +25,11 @@ test('collectTestFiles returns sorted repo-relative supported tests', () => {
 			'.github/workflows/b.test.mjs',
 			"import test from 'node:test'; test('b', () => {});",
 		);
+		writeFixture(
+			root,
+			'.git/ignored.test.ts',
+			"import test from 'node:test'; test('ignored', () => {});",
+		);
 		writeFixture(root, 'src/b.test.ts', "import test from 'node:test'; test('b', () => {});");
 		writeFixture(root, 'src/a.test.ts', "import test from 'node:test'; test('a', () => {});");
 		writeFixture(root, 'src/ui/named-note-modal-test-support.ts', 'export {};');
@@ -103,7 +108,6 @@ test('run preserves the exact child test command and inherits stdio', () => {
 		assert.throws(
 			() =>
 				run({
-					createRequireImpl: () => ({ resolve: () => '/tmp/fake-jiti-package.json' }),
 					proc,
 					spawn: (...args) => {
 						calls.push(args);
@@ -152,7 +156,6 @@ test('run exits without spawning when no tests are discovered', () => {
 		assert.throws(
 			() =>
 				run({
-					createRequireImpl: () => ({ resolve: () => '/tmp/fake-jiti-package.json' }),
 					proc,
 					spawn: () => {
 						spawnCalled = true;

--- a/test-runner.test.mjs
+++ b/test-runner.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import process from 'node:process';
@@ -58,7 +58,11 @@ test('launcher returns non-zero when a discovered test fails', () => {
 			}),
 		);
 		writeFixture(root, 'node_modules/jiti/register.mjs', 'export {};');
-		writeFixture(root, 'pass.test.mjs', "import test from 'node:test'; test('pass', () => {});");
+		writeFixture(
+			root,
+			'pass.test.mjs',
+			"import test from 'node:test'; test('pass', () => {});",
+		);
 		writeFixture(
 			root,
 			'fail.test.mjs',
@@ -80,7 +84,11 @@ test('launcher returns non-zero when a discovered test fails', () => {
 test('run preserves the exact child test command and inherits stdio', () => {
 	const root = mkdtempSync(join(tmpdir(), 'football-notes-test-runner-'));
 	try {
-		writeFixture(root, 'nested/sample.test.ts', "import test from 'node:test'; test('ok', () => {});");
+		writeFixture(
+			root,
+			'nested/sample.test.ts',
+			"import test from 'node:test'; test('ok', () => {});",
+		);
 
 		const calls = [];
 		const proc = {
@@ -111,12 +119,7 @@ test('run preserves the exact child test command and inherits stdio', () => {
 		assert.equal(calls.length, 1);
 		assert.deepEqual(calls[0], [
 			'/usr/local/bin/node',
-			[
-				'--import',
-				'jiti/register',
-				'--test',
-				join(root, 'nested/sample.test.ts'),
-			],
+			['--import', 'jiti/register', '--test', join(root, 'nested/sample.test.ts')],
 			{
 				env: expectedEnv,
 				stdio: 'inherit',
@@ -164,4 +167,11 @@ test('run exits without spawning when no tests are discovered', () => {
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
+});
+
+test('package.json test script points at the launcher', () => {
+	const packageJson = JSON.parse(
+		readFileSync(new URL('./package.json', import.meta.url), 'utf8'),
+	);
+	assert.equal(packageJson.scripts.test, 'node test-runner.mjs');
 });

--- a/test-runner.test.mjs
+++ b/test-runner.test.mjs
@@ -7,7 +7,7 @@ import process from 'node:process';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-import { collectTestFiles } from './test-runner.mjs';
+import { collectTestFiles, run } from './test-runner.mjs';
 
 const launcherPath = fileURLToPath(new URL('./test-runner.mjs', import.meta.url));
 
@@ -47,10 +47,21 @@ test('collectTestFiles returns sorted repo-relative supported tests', () => {
 test('launcher returns non-zero when a discovered test fails', () => {
 	const root = mkdtempSync(join(tmpdir(), 'football-notes-test-runner-'));
 	try {
-		writeFixture(root, 'pass.test.ts', "import test from 'node:test'; test('pass', () => {});");
 		writeFixture(
 			root,
-			'fail.test.ts',
+			'node_modules/jiti/package.json',
+			JSON.stringify({
+				name: 'jiti',
+				exports: {
+					'./register': './register.mjs',
+				},
+			}),
+		);
+		writeFixture(root, 'node_modules/jiti/register.mjs', 'export {};');
+		writeFixture(root, 'pass.test.mjs', "import test from 'node:test'; test('pass', () => {});");
+		writeFixture(
+			root,
+			'fail.test.mjs',
 			"import assert from 'node:assert/strict'; import test from 'node:test'; test('fail', () => assert.fail('boom'));",
 		);
 
@@ -60,7 +71,96 @@ test('launcher returns non-zero when a discovered test fails', () => {
 		});
 
 		assert.notEqual(result.status, 0);
-		assert.match(result.stderr, /boom/);
+		assert.match(`${result.stdout}${result.stderr}`, /boom/);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test('run preserves the exact child test command and inherits stdio', () => {
+	const root = mkdtempSync(join(tmpdir(), 'football-notes-test-runner-'));
+	try {
+		writeFixture(root, 'nested/sample.test.ts', "import test from 'node:test'; test('ok', () => {});");
+
+		const calls = [];
+		const proc = {
+			cwd: () => root,
+			env: { ...process.env },
+			execPath: '/usr/local/bin/node',
+			exit(code) {
+				throw new Error(`exit:${code}`);
+			},
+		};
+
+		assert.throws(
+			() =>
+				run({
+					createRequireImpl: () => ({ resolve: () => '/tmp/fake-jiti-package.json' }),
+					proc,
+					spawn: (...args) => {
+						calls.push(args);
+						return { status: 0 };
+					},
+				}),
+			/exit:0/,
+		);
+
+		const expectedEnv = { ...process.env };
+		delete expectedEnv.NODE_TEST_CONTEXT;
+
+		assert.equal(calls.length, 1);
+		assert.deepEqual(calls[0], [
+			'/usr/local/bin/node',
+			[
+				'--import',
+				'jiti/register',
+				'--test',
+				join(root, 'nested/sample.test.ts'),
+			],
+			{
+				env: expectedEnv,
+				stdio: 'inherit',
+			},
+		]);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test('run exits without spawning when no tests are discovered', () => {
+	const root = mkdtempSync(join(tmpdir(), 'football-notes-test-runner-'));
+	try {
+		let spawnCalled = false;
+		const stderr = [];
+		const proc = {
+			cwd: () => root,
+			env: { ...process.env },
+			execPath: '/usr/local/bin/node',
+			exit(code) {
+				throw new Error(`exit:${code}`);
+			},
+			stderr: {
+				write(chunk) {
+					stderr.push(chunk);
+				},
+			},
+		};
+
+		assert.throws(
+			() =>
+				run({
+					createRequireImpl: () => ({ resolve: () => '/tmp/fake-jiti-package.json' }),
+					proc,
+					spawn: () => {
+						spawnCalled = true;
+						return { status: 0 };
+					},
+				}),
+			/exit:1/,
+		);
+
+		assert.equal(spawnCalled, false);
+		assert.match(stderr.join(''), /No test files found/);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}


### PR DESCRIPTION
This pull request introduces a custom test runner to the project, replacing the previous hardcoded list of test files in the `test` script. The new `test-runner.mjs` script automatically discovers and runs all test files in the repository, improving maintainability and scalability. Comprehensive tests for the test runner itself are also included to ensure reliability.

**Test runner improvements:**

* Added `test-runner.mjs`, a custom script that recursively discovers all `.test.ts` and `.test.mjs` files (excluding `node_modules`) and runs them using Node's test runner with `jiti` for TypeScript support.
* Updated the `test` script in `package.json` to use the new test runner, simplifying test execution and removing the need to manually list test files.

**Test coverage for the test runner:**

* Added `test-runner.test.mjs`, which thoroughly tests the test runner’s file discovery, error handling, and integration with the Node test runner. It also verifies that the `test` script in `package.json` points to the new runner.

**Related Issues:**

* Resolve #64 