### PR TITLE
docs: add a user-facing Usage section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,39 @@ Planned focus areas:
 - isolated provider integrations
 - preserving user-authored note content during refresh flows
 
+## Usage
+
+### Installation
+
+- For end-user installs, download `main.js` and `manifest.json` from the relevant GitHub release and copy them into `<Vault>/.obsidian/plugins/football-notes/`.
+- If you're developing from source, use the direct-checkout workflow in [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+### Commands
+
+- `Create match note from URL`: validate a football match URL, create a structured placeholder note, and open it. It does not fetch teams, scores, dates, lineups, statistics, or provider data.
+- `Create match note manually`: collect home team, away team, match date, competition, and optional source URL; reuse or create linked team notes; then create the match note.
+- `Create team note`: create or reuse a team note from a team name.
+- `Create player note`: create or reuse a player note from a player name.
+
+### Settings and generated notes
+
+- Match notes use `Football notes/matches` by default, team notes use `Football notes/teams`, and player notes use `Football notes/players`.
+- Folder values are vault-relative and normalized before use.
+- Existing compatible team and player notes are reused instead of duplicated.
+- Match notes are not reused solely because a generated path is occupied; the plugin chooses an available filename instead.
+- The plugin avoids overwriting existing notes and reports folder or incompatible-note collisions clearly.
+- Manual match note home and away teams must be different. Names that resolve to the same sanitized, case-insensitive team-note path are rejected.
+- Manual match creation can leave already-created team notes in the vault if match-note creation fails later.
+- See the [canonical match note schema](./docs/match-note-schema.md) and [team/player note schemas](./docs/team-player-note-schema.md) for the note shapes.
+
+### Limitations
+
+- No provider-backed fetching yet.
+- No score extraction, statistics extraction, or lineup extraction yet.
+- No automatic player creation from matches yet.
+- No fuzzy alias matching yet.
+- No automatic rewriting of existing user-authored notes yet.
+
 ## Development
 
 Requirements:

--- a/src/readme-usage.test.ts
+++ b/src/readme-usage.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import { CREATE_MATCH_NOTE_FROM_URL_COMMAND_NAME } from './commands/create-match-note-from-url';
+import { CREATE_MATCH_NOTE_MANUALLY_COMMAND_NAME } from './commands/create-match-note-manually';
+import { CREATE_PLAYER_NOTE_COMMAND_NAME } from './commands/create-player-note';
+import { CREATE_TEAM_NOTE_COMMAND_NAME } from './commands/create-team-note';
+import {
+	DEFAULT_MATCH_NOTES_FOLDER,
+	DEFAULT_PLAYER_NOTES_FOLDER,
+	DEFAULT_TEAM_NOTES_FOLDER,
+} from './types';
+
+void test('README usage section documents the public contract', async () => {
+	const readme = await readFile(new URL('../README.md', import.meta.url), 'utf8');
+	const headingIndex = (heading: string) => readme.search(new RegExp(`^${heading}$`, 'm'));
+	const usageStart = headingIndex('## Usage');
+	const developmentStart = headingIndex('## Development');
+	const releasesStart = headingIndex('## Releases');
+	const localTestingStart = headingIndex('## Local testing');
+
+	assert.ok(usageStart >= 0);
+	assert.ok(developmentStart > usageStart);
+	assert.ok(releasesStart > developmentStart);
+	assert.ok(localTestingStart > releasesStart);
+
+	const usageSection = readme.slice(usageStart, developmentStart);
+	const usageHeadings = [...usageSection.matchAll(/^### .+$/gm)].map((match) => match[0]);
+
+	assert.deepEqual(usageHeadings, [
+		'### Installation',
+		'### Commands',
+		'### Settings and generated notes',
+		'### Limitations',
+	]);
+	assert.ok(
+		usageSection.includes(
+			'download `main.js` and `manifest.json` from the relevant GitHub release',
+		),
+	);
+	assert.ok(
+		usageSection.includes("If you're developing from source, use the direct-checkout workflow"),
+	);
+	assert.ok(!usageSection.includes('styles.css'));
+	assert.ok(usageSection.includes(CREATE_MATCH_NOTE_FROM_URL_COMMAND_NAME));
+	assert.ok(usageSection.includes(CREATE_MATCH_NOTE_MANUALLY_COMMAND_NAME));
+	assert.ok(usageSection.includes(CREATE_TEAM_NOTE_COMMAND_NAME));
+	assert.ok(usageSection.includes(CREATE_PLAYER_NOTE_COMMAND_NAME));
+	assert.ok(usageSection.includes(DEFAULT_MATCH_NOTES_FOLDER));
+	assert.ok(usageSection.includes(DEFAULT_TEAM_NOTES_FOLDER));
+	assert.ok(usageSection.includes(DEFAULT_PLAYER_NOTES_FOLDER));
+	assert.ok(usageSection.includes('docs/match-note-schema.md'));
+	assert.ok(usageSection.includes('docs/team-player-note-schema.md'));
+	assert.ok(
+		usageSection.includes(
+			'Existing compatible team and player notes are reused instead of duplicated.',
+		),
+	);
+	assert.ok(
+		usageSection.includes(
+			'Match notes are not reused solely because a generated path is occupied; the plugin chooses an available filename instead.',
+		),
+	);
+	assert.ok(
+		usageSection.includes(
+			'The plugin avoids overwriting existing notes and reports folder or incompatible-note collisions clearly.',
+		),
+	);
+	assert.ok(
+		usageSection.includes(
+			'Manual match note home and away teams must be different. Names that resolve to the same sanitized, case-insensitive team-note path are rejected.',
+		),
+	);
+	assert.ok(
+		usageSection.includes(
+			'It does not fetch teams, scores, dates, lineups, statistics, or provider data.',
+		),
+	);
+	assert.ok(usageSection.includes('automatic player creation from matches'));
+});


### PR DESCRIPTION
This pull request adds a comprehensive "Usage" section to the `README.md` to clearly document installation, commands, settings, and limitations for end users and developers. Additionally, it introduces a new test (`src/readme-usage.test.ts`) that ensures the README's usage documentation stays in sync with the plugin’s public contract and configuration.

**Documentation improvements:**

* Added a detailed "Usage" section to `README.md`, covering installation instructions, available commands, note generation behavior, and current limitations of the plugin.

**Testing and contract enforcement:**

* Introduced `src/readme-usage.test.ts`, a test that validates the structure and content of the README’s usage section, ensuring that all public commands, default folder settings, and documentation links are present and correct.

**Related Issues:**

* Resolve #62 