### PR TITLE
docs: document pull request title and squash-merge conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ See:
 ## Repository invariants
 
 - Keep changes scoped to the requested issue and avoid unrelated refactors.
+- Use an appropriate Conventional Commit-style pull request title. Because the title normally becomes the squash commit subject and affects Release Please, reserve `feat:` and `fix:` for changes to shipped plugin behavior; use types such as `docs:`, `test:`, `ci:`, `refactor:`, or `chore(release):` for non-product changes.
 - Preserve user-authored note content.
 - Keep provider-specific logic isolated from core note generation.
 - Use Obsidian APIs for vault and file operations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,35 @@ This repository uses Conventional Commits because Release Please reads commit hi
 - `feat!:` / `fix!:` / `refactor!:` and other `!` commits mark breaking changes
 - `chore:`, `docs:`, and most `refactor:` commits do not trigger releases by themselves
 
+### Pull request titles and squash merges
+
+Normal pull request titles must use Conventional Commit format:
+
+```text
+<type>(optional-scope): <summary>
+```
+
+Pull requests are normally squash-merged. The pull request title therefore normally becomes the final squash commit subject on `main`, which Release Please uses to classify the change and prepare the changelog and version bump.
+
+Reserve `feat:` and `fix:` for changes to shipped plugin behavior:
+
+- Use `feat:` when adding a new plugin capability or other user-facing behavior.
+- Use `fix:` when correcting existing shipped plugin behavior.
+
+Use an appropriate non-product type when the shipped plugin behavior is unchanged:
+
+| Change                                  | Example pull request title                       |
+| --------------------------------------- | ------------------------------------------------ |
+| Documentation only                      | `docs: document pull request conventions`        |
+| Tests only                              | `test: cover test-file discovery`                |
+| CI only                                 | `ci: update validation workflow`                 |
+| Behavior-preserving restructuring       | `refactor: simplify note creation wiring`        |
+| Release tooling or workflow maintenance | `chore(release): harden version synchronization` |
+
+A scope does not override the Conventional Commit type. For example, `fix(ci):` and `fix(release):` are still `fix` commits and can be classified as bug fixes by Release Please. Use `ci:` or `chore(release):` when the change does not correct shipped plugin behavior.
+
+Before squash-merging a pull request, verify that the final squash commit subject uses the intended Conventional Commit type. Correct the subject in GitHub's merge form when necessary.
+
 Release Please manages `package.json`, `package-lock.json`, `manifest.json`, and `CHANGELOG.md` after merges to `main`.
 Tags intentionally omit a leading `v` so Git tags match the Obsidian plugin version format.
 


### PR DESCRIPTION
This pull request updates the documentation to clarify and enforce the use of Conventional Commit-style pull request titles, especially in the context of squash merges and Release Please automation. The main goal is to ensure that commit types accurately reflect the nature of the change, which helps with versioning and changelog generation.

**Documentation updates:**

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R87-R115): Added a new section detailing how pull request titles should use the Conventional Commit format, explaining how the title becomes the squash commit subject, and providing a table of examples for different change types. Also clarifies the distinction between product and non-product commit types and how scopes interact with commit classification.
* [`AGENTS.md`](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R25): Updated repository invariants to require an appropriate Conventional Commit-style pull request title, with guidance on when to use `feat:`, `fix:`, and non-product types such as `docs:`, `test:`, `ci:`, `refactor:`, and `chore(release):`.

**Related Issues:**

* Resolve #69 